### PR TITLE
fix Texture::channels to support BGR and BGRA

### DIFF
--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -80,6 +80,8 @@ size_t Texture::channels() const {
         case PixelFormat::RA:           result = 2;  break;
         case PixelFormat::RGB:          result = 3;  break;
         case PixelFormat::RGBA:         result = 4;  break;
+        case PixelFormat::BGR:          result = 3;  break;
+        case PixelFormat::BGRA:         result = 4;  break;
         case PixelFormat::Depth:        result = 1;  break;
         case PixelFormat::DepthStencil: result = 2;  break;
         default: throw std::runtime_error("Texture::channels(): invalid "


### PR DESCRIPTION
The switch statement in Texture::channels was missing the BGR and BGRA cases, so these always fell through to the default error case.  This was a bug because, in general, a system may support BGR and BGRA as texture formats; indeed, some systems (such as Mac) may prefer these formats (at least in combination with the UInt8 component format).  If a system does not support BGR and BGRA as texture formats, this should be handled in the implementation of Texture::init.

I have fixed the bug by adding BGR and BGRA cases to Texture::channels.