### PR TITLE
restore #include directives needed after removing enoki

### DIFF
--- a/include/nanogui/common.h
+++ b/include/nanogui/common.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <functional>
 #include <vector>
 #include <string>
 

--- a/include/nanogui/vector.h
+++ b/include/nanogui/vector.h
@@ -11,8 +11,10 @@
 
 #include <nanogui/common.h>
 #include <nanogui/traits.h>
+#include <cassert>
 #include <cmath>
 #include <iosfwd>
+#include <string.h> // memset
 
 NAMESPACE_BEGIN(nanogui)
 

--- a/src/example1.cpp
+++ b/src/example1.cpp
@@ -37,6 +37,7 @@
 #include <nanogui/shader.h>
 #include <nanogui/renderpass.h>
 #include <iostream>
+#include <memory>
 #include <stb_image.h>
 
 using namespace nanogui;

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -1,5 +1,6 @@
 #include <nanogui/texture.h>
 #include <stb_image.h>
+#include <memory>
 
 NAMESPACE_BEGIN(nanogui)
 

--- a/src/texture_gl.cpp
+++ b/src/texture_gl.cpp
@@ -1,6 +1,7 @@
 #include <nanogui/texture.h>
 #include <nanogui/opengl.h>
 #include "opengl_check.h"
+#include <memory>
 
 #if !defined(GL_HALF_FLOAT)
 #  define GL_HALF_FLOAT 0x140B


### PR DESCRIPTION
Needed on fedora 29 // gcc 8.3.1, but did not need these includes for `clang`.  Not sure who is right here.