### PR TITLE
Proposal - recurring function execution

### DIFF
--- a/include/nanogui/common.h
+++ b/include/nanogui/common.h
@@ -441,6 +441,12 @@ extern NANOGUI_EXPORT bool active();
 extern NANOGUI_EXPORT void async(const std::function<void()> &func);
 
 /**
+ * \brief Schedule a function to be executed periodically when
+ * the application is redrawn the next time.
+ */
+extern NANOGUI_EXPORT void recurring(const std::function<void()> &func);
+
+/**
  * \brief Open a native file open/save dialog.
  *
  * \param filetypes

--- a/include/nanogui/common.h
+++ b/include/nanogui/common.h
@@ -447,6 +447,11 @@ extern NANOGUI_EXPORT void async(const std::function<void()> &func);
 extern NANOGUI_EXPORT void recurring(const std::function<void()> &func);
 
 /**
+ * \brief Sets interval in which recurring functions should be executed.
+ */
+extern NANOGUI_EXPORT void set_recurring_execution_interval(double interval);
+
+/**
  * \brief Open a native file open/save dialog.
  *
  * \param filetypes

--- a/include/nanogui/common.h
+++ b/include/nanogui/common.h
@@ -442,12 +442,14 @@ extern NANOGUI_EXPORT void async(const std::function<void()> &func);
 
 /**
  * \brief Schedule a function to be executed periodically when
- * the application is redrawn the next time.
+ * the application is being redrawn roughly each second by default.
+ * Interval can be changed by ``set_recurring_execution_interval`` function.
  */
 extern NANOGUI_EXPORT void recurring(const std::function<void()> &func);
 
 /**
  * \brief Sets interval in which recurring functions should be executed.
+ * Value of 1.0 roughly equals to 1 second.
  */
 extern NANOGUI_EXPORT void set_recurring_execution_interval(double interval);
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -83,10 +83,11 @@ std::vector<std::function<void()>> m_async_functions;
 std::mutex m_recurring_mutex;
 std::vector<std::function<void()>> m_recurring_functions;
 double m_last_iteration = 0.f;
+double m_recurring_execution_interval = 1.0f;
 
 void run_recurring_functions() {
     double elapsed = glfwGetTime() - m_last_iteration;
-    if (elapsed > 1.0f) {
+    if (elapsed > m_recurring_execution_interval) {
         m_last_iteration = glfwGetTime();
         std::lock_guard<std::mutex> guard(m_recurring_mutex);
         for (auto &f : m_recurring_functions)
@@ -219,6 +220,10 @@ void async(const std::function<void()> &func) {
 void recurring(const std::function<void()> &func) {
     std::lock_guard<std::mutex> guard(m_recurring_mutex);
     m_recurring_functions.push_back(func);
+}
+
+void set_recurring_execution_interval(double interval) {
+    m_recurring_execution_interval = interval;
 }
 
 void leave() {


### PR DESCRIPTION
**Proposal**
Proposal is to have a functionality to let user of nanogui schedule his own functions to be executed periodically during main application loop. Execution of those functions depends on set interval in which they should be run.

**Reasoning**
It may be sometimes handy to be able to run some code periodically on main application loop (you can not update UI from another thread directly on macOS for instance) in GUI applications. This PR gives user such ability but without managing GLFW and other stuff themselves and relying only on nanogui, which improves usability of the library.