### PR TITLE
Added an option to draw the graph vertically

### DIFF
--- a/include/nanogui/graph.h
+++ b/include/nanogui/graph.h
@@ -50,12 +50,17 @@ public:
     std::vector<float> &values() { return m_values; }
     void set_values(const std::vector<float> &values) { m_values = values; }
 
+    const bool& draw_vertical() const { return m_do_draw_vertical; }
+    void set_draw_vertical(const bool& do_draw_vertical) { m_do_draw_vertical = do_draw_vertical; }
+
     virtual Vector2i preferred_size(NVGcontext *ctx) const override;
     virtual void draw(NVGcontext *ctx) override;
 protected:
     std::string m_caption, m_header, m_footer;
     Color m_background_color, m_fill_color, m_stroke_color, m_text_color;
     std::vector<float> m_values;
+
+    bool m_do_draw_vertical;
 };
 
 NAMESPACE_END(nanogui)

--- a/python/misc.cpp
+++ b/python/misc.cpp
@@ -44,7 +44,9 @@ void register_misc(py::module &m) {
         .def("text_color", &Graph::text_color, D(Graph, text_color))
         .def("set_text_color", &Graph::set_text_color, D(Graph, set_text_color))
         .def("values", (std::vector<float> &(Graph::*)(void)) &Graph::values, D(Graph, values))
-        .def("set_values", &Graph::set_values, D(Graph, set_values));
+        .def("set_values", &Graph::set_values, D(Graph, set_values))
+        .def("draw_vertical", &Graph::draw_vertical, D(Graph, draw_vertical))
+        .def("set_draw_vertical", &Graph::set_draw_vertical, D(Graph, set_draw_vertical));
 
     py::class_<ImagePanel, Widget, ref<ImagePanel>, PyImagePanel>(m, "ImagePanel", D(ImagePanel))
         .def(py::init<Widget *>(), "parent"_a, D(ImagePanel, ImagePanel))

--- a/python/py_doc.h
+++ b/python/py_doc.h
@@ -1132,6 +1132,8 @@ static const char *__doc_nanogui_Graph_set_text_color = R"doc()doc";
 
 static const char *__doc_nanogui_Graph_set_values = R"doc()doc";
 
+static const char* __doc_nanogui_Graph_set_draw_vertical = R"doc()doc";
+
 static const char *__doc_nanogui_Graph_stroke_color = R"doc()doc";
 
 static const char *__doc_nanogui_Graph_text_color = R"doc()doc";
@@ -1139,6 +1141,8 @@ static const char *__doc_nanogui_Graph_text_color = R"doc()doc";
 static const char *__doc_nanogui_Graph_values = R"doc()doc";
 
 static const char *__doc_nanogui_Graph_values_2 = R"doc()doc";
+
+static const char* __doc_nanogui_Graph_draw_vertical = R"doc()doc";
 
 static const char *__doc_nanogui_GridLayout =
 R"doc(Grid layout.

--- a/python/vector.cpp
+++ b/python/vector.cpp
@@ -17,7 +17,7 @@ auto register_vector_type(py::module &m, const char *name) {
 
     array.def(py::init<Value>())
          .def(py::init<const Array &>())
-         .def(py::init([](const std::array<Value, Size> &arr) {
+         .def(py::init([Size](const std::array<Value, Size> &arr) {
             Array a;
             for (size_t i = 0; i < Size; ++i)
                 a[i] = arr[i];
@@ -37,12 +37,12 @@ auto register_vector_type(py::module &m, const char *name) {
          .def(py::self -= py::self)
          .def(py::self *= py::self)
          .def(py::self /= py::self)
-         .def("__getitem__", [](const Array &a, size_t index) -> Value {
+         .def("__getitem__", [Size](const Array &a, size_t index) -> Value {
              if (index >= Size)
                  throw py::index_error();
              return a[index];
          }, "index"_a)
-         .def("__setitem__", [](Array &a, size_t index, Value value) {
+         .def("__setitem__", [Size](Array &a, size_t index, Value value) {
              if (index >= Size)
                  throw py::index_error();
              a[index] = value;
@@ -51,7 +51,7 @@ auto register_vector_type(py::module &m, const char *name) {
                             [](Array &a, const Value &v) { a.x() = v; })
          .def_property("y", [](const Array &a) { return a.y(); },
                             [](Array &a, const Value &v) { a.y() = v; })
-         .def_buffer([](Array &m) -> py::buffer_info {
+         .def_buffer([Size](Array &m) -> py::buffer_info {
               return py::buffer_info(
                   m.v,                                    // Pointer to buffer
                   sizeof(Value),                          // Size of one scalar

--- a/src/example1.cpp
+++ b/src/example1.cpp
@@ -38,6 +38,9 @@
 #include <nanogui/renderpass.h>
 #include <iostream>
 #include <memory>
+
+#define STB_IMAGE_STATIC
+#define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 
 using namespace nanogui;

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -21,6 +21,7 @@ Graph::Graph(Widget *parent, const std::string &caption)
     m_fill_color = Color(255, 192, 0, 128);
     m_stroke_color = Color(100, 255);
     m_text_color = Color(240, 192);
+    m_do_draw_vertical = false;
 }
 
 Vector2i Graph::preferred_size(NVGcontext *) const {
@@ -39,15 +40,30 @@ void Graph::draw(NVGcontext *ctx) {
         return;
 
     nvgBeginPath(ctx);
-    nvgMoveTo(ctx, m_pos.x(), m_pos.y()+m_size.y());
-    for (size_t i = 0; i < (size_t) m_values.size(); i++) {
-        float value = m_values[i];
-        float vx = m_pos.x() + i * m_size.x() / (float) (m_values.size() - 1);
-        float vy = m_pos.y() + (1-value) * m_size.y();
-        nvgLineTo(ctx, vx, vy);
-    }
+    if (m_do_draw_vertical)
+    {
+        nvgMoveTo(ctx, m_pos.x(), m_pos.y());
+        for (size_t i = 0; i < (size_t)m_values.size(); i++) {
+            float value = m_values[i];
+            float vy = m_pos.y() + i * m_size.y() / (float)(m_values.size() - 1);
+            float vx = m_pos.x() + (1 - value) * m_size.x();
+            nvgLineTo(ctx, vx, vy);
+        }
 
-    nvgLineTo(ctx, m_pos.x() + m_size.x(), m_pos.y() + m_size.y());
+        nvgLineTo(ctx, m_pos.x(), m_pos.y() + m_size.y());
+    }
+    else
+    {
+        nvgMoveTo(ctx, m_pos.x(), m_pos.y() + m_size.y());
+        for (size_t i = 0; i < (size_t)m_values.size(); i++) {
+            float value = m_values[i];
+            float vx = m_pos.x() + i * m_size.x() / (float)(m_values.size() - 1);
+            float vy = m_pos.y() + (1 - value) * m_size.y();
+            nvgLineTo(ctx, vx, vy);
+        }
+
+        nvgLineTo(ctx, m_pos.x() + m_size.x(), m_pos.y() + m_size.y());
+    }
     nvgStrokeColor(ctx, m_stroke_color);
     nvgStroke(ctx);
     if (m_fill_color.w() > 0) {

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -76,26 +76,6 @@ static bool glad_initialized = false;
 static float get_pixel_ratio(GLFWwindow *window) {
 #if defined(EMSCRIPTEN)
     return emscripten_get_device_pixel_ratio();
-#elif defined(_WIN32)
-    HWND hwnd = glfwGetWin32Window(window);
-    HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-    /* The following function only exists on Windows 8.1+, but we don't want to make that a dependency */
-    static HRESULT (WINAPI *GetDpiForMonitor_)(HMONITOR, UINT, UINT*, UINT*) = nullptr;
-    static bool GetDpiForMonitor_tried = false;
-
-    if (!GetDpiForMonitor_tried) {
-        auto shcore = LoadLibrary(TEXT("shcore"));
-        if (shcore)
-            GetDpiForMonitor_ = (decltype(GetDpiForMonitor_)) GetProcAddress(shcore, "GetDpiForMonitor");
-        GetDpiForMonitor_tried = true;
-    }
-
-    if (GetDpiForMonitor_) {
-        uint32_t dpi_x, dpi_y;
-        if (GetDpiForMonitor_(monitor, 0 /* effective DPI */, &dpi_x, &dpi_y) == S_OK)
-            return dpi_x / 96.0;
-    }
-    return 1.f;
 #elif defined(__linux__)
     (void) window;
 


### PR DESCRIPTION
This introduces an optional setter to the Graph class/widget, `set_draw_vertical(bool)`. This sets an internal boolean `do_draw_vertical` which, when set to true, will cause the graph to be effectively rotated by 90 degrees: the graph is drawn with value magnitudes appearing along the horizontal axis rather than the vertical.