### PR TITLE
fix(tab-widget): Tab widgets with no callback do not update visibility

### DIFF
--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -300,8 +300,9 @@ bool TabWidgetBase::mouse_button_event(const Vector2i &p, int button, bool down,
                     m_tab_drag_min = m_tab_offsets[index];
                     m_tab_drag_max = m_tab_offsets[index + 1];
                     m_close_index_pushed = -1;
-                    if (tab_changed && m_callback) {
-                        m_callback(selected_id());
+                    if (tab_changed) {
+						if(m_callback)
+                        	m_callback(selected_id());
                         update_visibility();
                     }
                 } else if (m_tab_drag_index != -1) {


### PR DESCRIPTION
When no callback is set, the tab widget fails to update visibility of its children due to an erroneous if condition.