### PR TITLE
Fix for compilation error in example1 regarding STB_IMAGE

### DIFF
--- a/src/example1.cpp
+++ b/src/example1.cpp
@@ -38,6 +38,9 @@
 #include <nanogui/renderpass.h>
 #include <iostream>
 #include <memory>
+
+#define STB_IMAGE_STATIC
+#define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 
 using namespace nanogui;


### PR DESCRIPTION
Just a minor fix for a compilation error I was getting on windows.  I just re-added the STB_IMAGE defines that were in the old repo wjakob/nanogui.

https://github.com/wjakob/nanogui/blob/e9ec8a1a9861cf578d9c6e85a6420080aa715c03/src/example1.cpp#L53