### PR TITLE
Added resizable window class

### DIFF
--- a/include/nanogui/window.h
+++ b/include/nanogui/window.h
@@ -24,7 +24,7 @@ NAMESPACE_BEGIN(nanogui)
 class NANOGUI_EXPORT Window : public Widget {
     friend class Popup;
 public:
-    Window(Widget *parent, const std::string &title = "Untitled");
+    Window(Widget *parent, const std::string &title = "Window");
 
     /// Return the window title
     const std::string &title() const { return m_title; }
@@ -45,8 +45,14 @@ public:
     /// Center the window in the current \ref Screen
     void center();
 
-    /// Draw the window
-    virtual void draw(NVGcontext *ctx) override;
+     /// Draw the window frame
+    virtual void drawWindowFrame(NVGcontext* ctx);
+    /// Draw the window shadow
+    virtual void drawWindowShadow(NVGcontext* ctx);
+    /// Draw the window title bar
+    virtual void drawTitleBar(NVGcontext* ctx);
+   /// Draw the window
+    virtual void draw(NVGcontext* ctx) override;
     /// Handle mouse enter/leave events
     virtual bool mouse_enter_event(const Vector2i &p, bool enter) override;
     /// Handle window drag events
@@ -67,6 +73,32 @@ protected:
     Widget *m_button_panel;
     bool m_modal;
     bool m_drag;
+};
+
+/**
+ * \class Window window.h nanogui/window.h
+ *
+ * \brief Top-level window widget.
+ */
+class NANOGUI_EXPORT ResizableWindow : public Window {
+public:
+    ResizableWindow(Widget* parent, const std::string& title = "Resizable window", bool enforceMinHeight = true);
+    /// Draw the window
+    virtual void draw(NVGcontext* ctx) override;
+    bool mouse_button_event(const Vector2i& p, int button, bool down, int modifiers) override;
+    bool mouse_motion_event(const Vector2i& p, const Vector2i& rel, int button, int modifiers) override;
+    /// Accept scroll events and scroll in the window, or propagate them to the widget under the mouse cursor
+    virtual bool scroll_event(const Vector2i& p, const Vector2f& rel) override;
+    /// Invoke the associated layout generator to properly place child widgets, if any
+    virtual void perform_layout(NVGcontext* ctx) override;
+private:
+    bool m_resizing;
+    bool m_draggingScrollbar;
+    bool m_layoutChanged;
+    Vector2i m_downPos;
+    Vector2i m_preferred;
+    bool m_enforceMinHeight;
+    float m_scroll;
 };
 
 NAMESPACE_END(nanogui)

--- a/src/example1.cpp
+++ b/src/example1.cpp
@@ -38,6 +38,7 @@
 #include <nanogui/renderpass.h>
 #include <iostream>
 #include <memory>
+#define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 
 using namespace nanogui;
@@ -46,38 +47,38 @@ class ExampleApplication : public Screen {
 public:
     ExampleApplication() : Screen(Vector2i(1024, 768), "NanoGUI Test") {
         inc_ref();
-        Window *window = new Window(this, "Button demo");
-        window->set_position(Vector2i(15, 15));
-        window->set_layout(new GroupLayout());
+        
+        ResizableWindow *resizableWindow = new ResizableWindow(this, "Button demo");
+        resizableWindow->set_position(Vector2i(15, 15));
+        resizableWindow->set_layout(new GroupLayout());
+        
+        // No need to store a pointer, the data structure will be automatically freed when the parent window is deleted
+        new Label(resizableWindow, "Push buttons", "sans-bold");
 
-        /* No need to store a pointer, the data structure will be automatically
-           freed when the parent window is deleted */
-        new Label(window, "Push buttons", "sans-bold");
-
-        Button *b = new Button(window, "Plain button");
+        Button* b = new Button(resizableWindow, "Plain button");
         b->set_callback([] { std::cout << "pushed!" << std::endl; });
         b->set_tooltip("short tooltip");
 
-        /* Alternative construction notation using variadic template */
-        b = window->add<Button>("Styled", FA_ROCKET);
+        // Alternative construction notation using variadic template
+        b = resizableWindow->add<Button>("Styled", FA_ROCKET);
         b->set_background_color(Color(0, 0, 255, 25));
         b->set_callback([] { std::cout << "pushed!" << std::endl; });
         b->set_tooltip("This button has a fairly long tooltip. It is so long, in "
                 "fact, that the shown text will span several lines.");
 
-        new Label(window, "Toggle buttons", "sans-bold");
-        b = new Button(window, "Toggle me");
+        new Label(resizableWindow, "Toggle buttons", "sans-bold");
+        b = new Button(resizableWindow, "Toggle me");
         b->set_flags(Button::ToggleButton);
         b->set_change_callback([](bool state) { std::cout << "Toggle button state: " << state << std::endl; });
 
-        new Label(window, "Radio buttons", "sans-bold");
-        b = new Button(window, "Radio button 1");
+        new Label(resizableWindow, "Radio buttons", "sans-bold");
+        b = new Button(resizableWindow, "Radio button 1");
         b->set_flags(Button::RadioButton);
-        b = new Button(window, "Radio button 2");
+        b = new Button(resizableWindow, "Radio button 2");
         b->set_flags(Button::RadioButton);
 
-        new Label(window, "A tool palette", "sans-bold");
-        Widget *tools = new Widget(window);
+        new Label(resizableWindow, "A tool palette", "sans-bold");
+        Widget* tools = new Widget(resizableWindow);
         tools->set_layout(new BoxLayout(Orientation::Horizontal,
                                        Alignment::Middle, 0, 6));
 
@@ -86,8 +87,8 @@ public:
         b = new ToolButton(tools, FA_COMPASS);
         b = new ToolButton(tools, FA_UTENSILS);
 
-        new Label(window, "Popup buttons", "sans-bold");
-        PopupButton *popup_btn = new PopupButton(window, "Popup", FA_FLASK);
+        new Label(resizableWindow, "Popup buttons", "sans-bold");
+        PopupButton *popup_btn = new PopupButton(resizableWindow, "Popup", FA_FLASK);
         Popup *popup = popup_btn->popup();
         popup->set_layout(new GroupLayout());
         new Label(popup, "Arbitrary widgets can be placed here");
@@ -103,34 +104,44 @@ public:
         Popup *popup_left = popup_btn->popup();
         popup_left->set_layout(new GroupLayout());
         new CheckBox(popup_left, "Another check box");
+       
+        resizableWindow = new ResizableWindow(this, "Scrollable resizableWindow");
+        resizableWindow->set_position(Vector2i(15, 500));
+        resizableWindow->set_layout(new GroupLayout());
 
-        window = new Window(this, "Basic widgets");
-        window->set_position(Vector2i(200, 15));
-        window->set_layout(new GroupLayout());
 
-        new Label(window, "Message dialog", "sans-bold");
-        tools = new Widget(window);
+        new Label(resizableWindow, "Message dialog", "sans-bold");
+        tools = new Widget(resizableWindow);
         tools->set_layout(new BoxLayout(Orientation::Horizontal,
-                                       Alignment::Middle, 0, 6));
+            Alignment::Middle, 0, 6));
         b = new Button(tools, "Info");
         b->set_callback([&] {
             auto dlg = new MessageDialog(this, MessageDialog::Type::Information, "Title", "This is an information message");
             dlg->set_callback([](int result) { std::cout << "Dialog result: " << result << std::endl; });
-        });
+            });
         b = new Button(tools, "Warn");
         b->set_callback([&] {
             auto dlg = new MessageDialog(this, MessageDialog::Type::Warning, "Title", "This is a warning message");
             dlg->set_callback([](int result) { std::cout << "Dialog result: " << result << std::endl; });
-        });
+            });
         b = new Button(tools, "Ask");
         b->set_callback([&] {
             auto dlg = new MessageDialog(this, MessageDialog::Type::Warning, "Title", "This is a question message", "Yes", "No", true);
             dlg->set_callback([](int result) { std::cout << "Dialog result: " << result << std::endl; });
-        });
+            });
+        popup_btn = new PopupButton(resizableWindow, "Popup", FA_FLASK);
+        popup = popup_btn->popup();
+        popup->set_layout(new GroupLayout());
+        new Label(popup, "Arbitrary widgets can be placed here");
+        new CheckBox(popup, "A check box");
+        
+        resizableWindow = new ResizableWindow(this, "Basic widgets", false);
+        resizableWindow->set_position(Vector2i(200, 15));
+        resizableWindow->set_layout(new GroupLayout());
 
 #if defined(_WIN32)
         /// Executable is in the Debug/Release/.. subdirectory
-        std::string resources_folder_path("../icons");
+        std::string resources_folder_path("../../../Resources/icons");
 #else
         std::string resources_folder_path("./icons");
 #endif
@@ -144,8 +155,8 @@ public:
         }
 #endif
 
-        new Label(window, "Image panel & scroll panel", "sans-bold");
-        PopupButton *image_panel_btn = new PopupButton(window, "Image Panel");
+        new Label(resizableWindow, "Image panel & scroll panel", "sans-bold");
+        PopupButton *image_panel_btn = new PopupButton(resizableWindow, "Image Panel");
         image_panel_btn->set_icon(FA_IMAGES);
         popup = image_panel_btn->popup();
         VScrollPanel *vscroll = new VScrollPanel(popup);
@@ -201,8 +212,8 @@ public:
             }
         );
 
-        new Label(window, "File dialog", "sans-bold");
-        tools = new Widget(window);
+        new Label(resizableWindow, "File dialog", "sans-bold");
+        tools = new Widget(resizableWindow);
         tools->set_layout(new BoxLayout(Orientation::Horizontal,
                                        Alignment::Middle, 0, 6));
         b = new Button(tools, "Open");
@@ -216,22 +227,22 @@ public:
                     { {"png", "Portable Network Graphics"}, {"txt", "Text file"} }, true) << std::endl;
         });
 
-        new Label(window, "Combo box", "sans-bold");
-        new ComboBox(window, { "Combo box item 1", "Combo box item 2", "Combo box item 3"});
-        new Label(window, "Check box", "sans-bold");
-        CheckBox *cb = new CheckBox(window, "Flag 1",
+        new Label(resizableWindow, "Combo box", "sans-bold");
+        new ComboBox(resizableWindow, { "Combo box item 1", "Combo box item 2", "Combo box item 3"});
+        new Label(resizableWindow, "Check box", "sans-bold");
+        CheckBox *cb = new CheckBox(resizableWindow, "Flag 1",
             [](bool state) { std::cout << "Check box 1 state: " << state << std::endl; }
         );
         cb->set_checked(true);
-        cb = new CheckBox(window, "Flag 2",
+        cb = new CheckBox(resizableWindow, "Flag 2",
             [](bool state) { std::cout << "Check box 2 state: " << state << std::endl; }
         );
-        new Label(window, "Progress bar", "sans-bold");
-        m_progress = new ProgressBar(window);
+        new Label(resizableWindow, "Progress bar", "sans-bold");
+        m_progress = new ProgressBar(resizableWindow);
 
-        new Label(window, "Slider and text box", "sans-bold");
+        new Label(resizableWindow, "Slider and text box", "sans-bold");
 
-        Widget *panel = new Widget(window);
+        Widget *panel = new Widget(resizableWindow);
         panel->set_layout(new BoxLayout(Orientation::Horizontal,
                                        Alignment::Middle, 0, 20));
 
@@ -253,7 +264,7 @@ public:
         text_box->set_font_size(20);
         text_box->set_alignment(TextBox::Alignment::Right);
 
-        window = new Window(this, "Misc. widgets");
+        Window *window = new Window(this, "Misc. widgets");
         window->set_position(Vector2i(425,15));
         window->set_layout(new GroupLayout());
 
@@ -343,7 +354,8 @@ public:
         layout->set_spacing(0, 10);
         window->set_layout(layout);
 
-        /* FP widget */ {
+        // FP widget
+        {
             new Label(window, "Floating point :", "sans-bold");
             text_box = new TextBox(window);
             text_box->set_editable(true);
@@ -355,7 +367,8 @@ public:
             text_box->set_format("[-]?[0-9]*\\.?[0-9]+");
         }
 
-        /* Positive integer widget */ {
+        // Positive integer widget
+        {
             new Label(window, "Positive integer :", "sans-bold");
             auto int_box = new IntBox<int>(window);
             int_box->set_editable(true);
@@ -370,7 +383,8 @@ public:
             int_box->set_value_increment(2);
         }
 
-        /* Checkbox widget */ {
+        // Checkbox widget
+        {
             new Label(window, "Checkbox :", "sans-bold");
 
             cb = new CheckBox(window, "Check me");
@@ -430,7 +444,6 @@ public:
             int alpha = (int) (c.w() * 255.0f);
             alpha_int_box->set_value(alpha);
         });
-
         perform_layout();
 
         /* All NanoGUI widgets are initialized at this point. Now

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -65,82 +65,93 @@ void Window::perform_layout(NVGcontext *ctx) {
     }
 }
 
-void Window::draw(NVGcontext *ctx) {
-    int ds = m_theme->m_window_drop_shadow_size, cr = m_theme->m_window_corner_radius;
-    int hh = m_theme->m_window_header_height;
-
-    /* Draw window */
+void Window::drawWindowFrame(NVGcontext* ctx) {
+    int cr = m_theme->m_window_corner_radius;
     nvgSave(ctx);
     nvgBeginPath(ctx);
     nvgRoundedRect(ctx, m_pos.x(), m_pos.y(), m_size.x(), m_size.y(), cr);
 
     nvgFillColor(ctx, m_mouse_focus ? m_theme->m_window_fill_focused
-                                    : m_theme->m_window_fill_unfocused);
+        : m_theme->m_window_fill_unfocused);
     nvgFill(ctx);
+}
 
-
-    /* Draw a drop shadow */
+void Window::drawWindowShadow(NVGcontext* ctx) {
+    int ds = m_theme->m_window_drop_shadow_size;
+    int cr = m_theme->m_window_corner_radius;
     NVGpaint shadow_paint = nvgBoxGradient(
-        ctx, m_pos.x(), m_pos.y(), m_size.x(), m_size.y(), cr*2, ds*2,
+        ctx, m_pos.x(), m_pos.y(), m_size.x(), m_size.y(), cr * 2, ds * 2,
         m_theme->m_drop_shadow, m_theme->m_transparent);
 
     nvgSave(ctx);
     nvgResetScissor(ctx);
     nvgBeginPath(ctx);
-    nvgRect(ctx, m_pos.x()-ds,m_pos.y()-ds, m_size.x()+2*ds, m_size.y()+2*ds);
+    nvgRect(ctx, m_pos.x() - ds, m_pos.y() - ds, m_size.x() + 2 * ds, m_size.y() + 2 * ds);
     nvgRoundedRect(ctx, m_pos.x(), m_pos.y(), m_size.x(), m_size.y(), cr);
     nvgPathWinding(ctx, NVG_HOLE);
     nvgFillPaint(ctx, shadow_paint);
     nvgFill(ctx);
     nvgRestore(ctx);
+}
 
+void Window::drawTitleBar(NVGcontext* ctx) {
+    int cr = m_theme->m_window_corner_radius;
+    int hh = m_theme->m_window_header_height;
+    NVGpaint header_paint = nvgLinearGradient(
+        ctx, m_pos.x(), m_pos.y(), m_pos.x(),
+        m_pos.y() + hh,
+        m_theme->m_window_header_gradient_top,
+        m_theme->m_window_header_gradient_bot);
+
+    nvgBeginPath(ctx);
+    nvgRoundedRect(ctx, m_pos.x(), m_pos.y(), m_size.x(), hh, cr);
+
+    nvgFillPaint(ctx, header_paint);
+    nvgFill(ctx);
+    ;
+    nvgBeginPath(ctx);
+    nvgRoundedRect(ctx, m_pos.x(), m_pos.y(), m_size.x(), hh, cr);
+    nvgStrokeColor(ctx, m_theme->m_window_header_sep_top);
+
+    nvgSave(ctx);
+    nvgIntersectScissor(ctx, m_pos.x(), m_pos.y(), m_size.x(), 0.5f);
+    nvgStroke(ctx);
+    nvgRestore(ctx);
+
+    nvgBeginPath(ctx);
+    nvgMoveTo(ctx, m_pos.x() + 0.5f, m_pos.y() + hh - 1.5f);
+    nvgLineTo(ctx, m_pos.x() + m_size.x() - 0.5f, m_pos.y() + hh - 1.5);
+    nvgStrokeColor(ctx, m_theme->m_window_header_sep_bot);
+    nvgStroke(ctx);
+
+    nvgFontSize(ctx, 18.0f);
+    nvgFontFace(ctx, "sans-bold");
+    nvgTextAlign(ctx, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+
+    nvgFontBlur(ctx, 2);
+    nvgFillColor(ctx, m_theme->m_drop_shadow);
+    nvgText(ctx, m_pos.x() + m_size.x() / 2,
+        m_pos.y() + hh / 2, m_title.c_str(), nullptr);
+
+    nvgFontBlur(ctx, 0);
+    nvgFillColor(ctx, m_focused ? m_theme->m_window_title_focused
+        : m_theme->m_window_title_unfocused);
+    nvgText(ctx, m_pos.x() + m_size.x() / 2, m_pos.y() + hh / 2 - 1,
+        m_title.c_str(), nullptr);
+}
+
+void Window::draw(NVGcontext *ctx) {
+    /* Draw window */
+    drawWindowFrame(ctx);
+    /* Draw a drop shadow */
+    drawWindowShadow(ctx);
     if (!m_title.empty()) {
         /* Draw header */
-        NVGpaint header_paint = nvgLinearGradient(
-            ctx, m_pos.x(), m_pos.y(), m_pos.x(),
-            m_pos.y() + hh,
-            m_theme->m_window_header_gradient_top,
-            m_theme->m_window_header_gradient_bot);
-
-        nvgBeginPath(ctx);
-        nvgRoundedRect(ctx, m_pos.x(), m_pos.y(), m_size.x(), hh, cr);
-
-        nvgFillPaint(ctx, header_paint);
-        nvgFill(ctx);
-
-        nvgBeginPath(ctx);
-        nvgRoundedRect(ctx, m_pos.x(), m_pos.y(), m_size.x(), hh, cr);
-        nvgStrokeColor(ctx, m_theme->m_window_header_sep_top);
-
-        nvgSave(ctx);
-        nvgIntersectScissor(ctx, m_pos.x(), m_pos.y(), m_size.x(), 0.5f);
-        nvgStroke(ctx);
-        nvgRestore(ctx);
-
-        nvgBeginPath(ctx);
-        nvgMoveTo(ctx, m_pos.x() + 0.5f, m_pos.y() + hh - 1.5f);
-        nvgLineTo(ctx, m_pos.x() + m_size.x() - 0.5f, m_pos.y() + hh - 1.5);
-        nvgStrokeColor(ctx, m_theme->m_window_header_sep_bot);
-        nvgStroke(ctx);
-
-        nvgFontSize(ctx, 18.0f);
-        nvgFontFace(ctx, "sans-bold");
-        nvgTextAlign(ctx, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
-
-        nvgFontBlur(ctx, 2);
-        nvgFillColor(ctx, m_theme->m_drop_shadow);
-        nvgText(ctx, m_pos.x() + m_size.x() / 2,
-                m_pos.y() + hh / 2, m_title.c_str(), nullptr);
-
-        nvgFontBlur(ctx, 0);
-        nvgFillColor(ctx, m_focused ? m_theme->m_window_title_focused
-                                    : m_theme->m_window_title_unfocused);
-        nvgText(ctx, m_pos.x() + m_size.x() / 2, m_pos.y() + hh / 2 - 1,
-                m_title.c_str(), nullptr);
+        drawTitleBar(ctx);
     }
+    Widget::draw(ctx);
 
     nvgRestore(ctx);
-    Widget::draw(ctx);
 }
 
 void Window::dispose() {
@@ -190,6 +201,149 @@ bool Window::scroll_event(const Vector2i &p, const Vector2f &rel) {
 
 void Window::refresh_relative_placement() {
     /* Overridden in \ref Popup */
+}
+
+ResizableWindow::ResizableWindow(Widget* parent, const std::string& title, bool enforceMinHeight)
+    : Window(parent, title),
+    m_resizing(false),
+    m_draggingScrollbar(false),
+    m_layoutChanged(false),
+    m_downPos(Vector2i(0, 0)),
+    m_preferred(Vector2i(0, 0)),
+    m_enforceMinHeight(enforceMinHeight),
+    m_scroll(0)
+{ }
+
+bool ResizableWindow::mouse_button_event(const Vector2i& p, int button, bool down, int modifiers)
+{
+    if (down) {
+        if (m_pos.x() + m_size.x() - p.x() < 10) {
+            m_downPos = p;
+            if (m_pos.y() + m_size.y() - p.y() < 10) {
+                m_resizing = true;
+                return true;
+            } else {
+                m_draggingScrollbar = true;
+                return true;
+            }
+        }
+    }
+    m_resizing = false;
+    m_draggingScrollbar = false;
+    return Window::mouse_button_event(p, button, down, modifiers);
+}
+bool ResizableWindow::mouse_motion_event(const Vector2i& p, const Vector2i& rel, int button, int modifiers)
+{
+    if (m_resizing) {
+        Vector2i delta = p - m_downPos;
+        Vector2i size = m_size + delta;
+        if (size.x() < m_preferred.x())
+            size = Vector2i(m_preferred.x(), size.y());
+        if (m_enforceMinHeight) {
+            if (size.y() < m_preferred.y())
+                size = Vector2i(size.x(), m_preferred.y());
+        }
+        set_size(size);
+        m_downPos = p;
+        m_layoutChanged = true;
+        return true;
+    } else if (m_draggingScrollbar) {
+        int hh = m_theme->m_window_header_height;
+        float scrollbarAreaHeight = m_size.y() - hh - 10;
+        float scrollHeight = scrollbarAreaHeight * m_size.y() / m_preferred.y();
+        float scrollTop = m_scroll * (scrollbarAreaHeight - scrollHeight);
+        scrollTop += p.y() - m_downPos.y();
+        m_scroll = scrollTop / (scrollbarAreaHeight - scrollHeight);
+        if (m_scroll < 0)
+            m_scroll = 0;
+        else if (m_scroll > 1)
+            m_scroll = 1;
+        m_layoutChanged = true;
+        m_downPos = p;
+        return true;
+    }
+    return Window::mouse_motion_event(p, rel, button, modifiers);
+}
+
+bool ResizableWindow::scroll_event(const Vector2i& p, const Vector2f& rel) {
+    if (m_size.y() < m_preferred.y()) {
+        float maxScroll = (m_preferred.y() - m_size.y());
+        float currentScroll = maxScroll * m_scroll;
+        currentScroll -= rel.y() * 16;
+        m_scroll = currentScroll / maxScroll;
+        if (m_scroll < 0)
+            m_scroll = 0;
+        else if (m_scroll > 1)
+            m_scroll = 1;
+        m_layoutChanged = true;
+        return true;
+    } else {
+        return Window::scroll_event(p, rel);
+    }
+}
+
+void ResizableWindow::perform_layout(NVGcontext* ctx) {
+    if (!m_button_panel) {
+        Widget::perform_layout(ctx);
+    } else {
+        m_button_panel->set_visible(false);
+        Widget::perform_layout(ctx);
+        for (auto w : m_button_panel->children()) {
+            w->set_fixed_size(Vector2i(22, 22));
+            w->set_font_size(15);
+        }
+        m_button_panel->set_visible(true);
+        m_button_panel->set_size(Vector2i(width(), 22));
+        m_button_panel->set_position(Vector2i(
+            width() - (m_button_panel->preferred_size(ctx).x() + 5), 3));
+        m_button_panel->perform_layout(ctx);
+    }
+    if (m_size.y() < m_preferred.y()) {
+        float maxScroll = (m_preferred.y() - m_size.y());
+        float currentScroll = maxScroll * m_scroll;
+        for (auto c : m_children) {
+            c->set_position(Vector2i(c->position().x(), c->position().y() - currentScroll));
+        }
+    }
+}
+
+void ResizableWindow::draw(NVGcontext* ctx) {
+    m_preferred = this->preferred_size(ctx);
+    if (m_layoutChanged) {
+        perform_layout(ctx);
+        m_layoutChanged = false;
+    }
+
+    /* Draw window */
+    drawWindowFrame(ctx);
+    /* Draw a drop shadow */
+    drawWindowShadow(ctx);
+    if (!m_title.empty()) {
+        /* Draw header */
+        drawTitleBar(ctx);
+    }
+    nvgIntersectScissor(ctx, m_pos.x(), m_pos.y() + m_theme->m_window_header_height, m_size.x(), m_size.y());
+    Widget::draw(ctx);
+
+    if (m_size.y() < m_preferred.y()) {
+        int cr = m_theme->m_window_corner_radius;
+        int hh = m_theme->m_window_header_height;
+        float scrollbarAreaHeight = m_size.y() - hh - 10;
+        float scrollHeight = scrollbarAreaHeight * m_size.y() / m_preferred.y();
+        nvgBeginPath(ctx);
+        nvgRoundedRect(ctx, m_pos.x() + m_size.x() - 8, m_pos.y() + hh + m_scroll * (scrollbarAreaHeight - scrollHeight), 6, scrollHeight, cr);
+
+        nvgFillColor(ctx, m_theme->m_window_header_gradient_top);
+        nvgFill(ctx);
+    }
+    nvgBeginPath(ctx);
+    nvgMoveTo(ctx, m_pos.x() + m_size.x() - 10, m_pos.y() + m_size.y());
+    nvgLineTo(ctx, m_pos.x() + m_size.x(), m_pos.y() + m_size.y() - 10);
+    nvgLineTo(ctx, m_pos.x() + m_size.x(), m_pos.y() + m_size.y());
+    nvgFillColor(ctx, m_theme->m_window_header_gradient_top);
+    nvgFill(ctx);
+
+    nvgRestore(ctx);
 }
 
 NAMESPACE_END(nanogui)


### PR DESCRIPTION
I've added a ResizableWindow class that is based on the standard Window class.

The window can be resized horizontally and vertically, but only a vertical scrollbar is implemented so there is a different behavior for width and height:
- Width can not be resized smaller than the minimum width needed to fully display all widgets
- If the width is more than the minimum needed, the layout of the window stretch horizontally
- Height can be resized smaller than the minimum height needed to fully display all widgets if enforceMinimumHeight is set to true in the constructor. In such case a scrollbar appears.
- If the height is more than the minimum needed, a blank area appears at the bottom of the window.

The main thinking behind this behavior is that horizontal scrollbars are probably bad UI design anyway. This might not suit the needs of everyone, but I'm creating this PR should people need this (or want to extend it further)

Hope it helps !