### PR TITLE
created directory_dialog for windows and linux

### DIFF
--- a/include/nanogui/common.h
+++ b/include/nanogui/common.h
@@ -294,6 +294,18 @@ extern NANOGUI_EXPORT void chdir_to_bundle_parent();
 #endif
 
 /**
+* \brief Open a native directory dialog.
+*
+*
+* \param saved_path
+*     Optional parameter to specify a directory that the dialog should start in.
+*/
+#if !defined(__APPLE__)
+    extern NANOGUI_EXPORT std::string
+    directory_dialog(std::string saved_path = "");
+#endif
+
+/**
  * \brief Convert a single UTF32 character code to UTF8.
  *
  * \rst

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -14,6 +14,7 @@
 #if defined(_WIN32)
 #  define NOMINMAX
 #  include <windows.h>
+#  include <shlobj.h>
 #endif
 
 #include <nanogui/opengl.h>
@@ -416,7 +417,71 @@ std::vector<std::string> file_dialog(const std::vector<std::pair<std::string, st
 }
 #endif
 
-void Object::inc_ref() const {
+
+
+#if !defined(__APPLE__)
+    #if !defined(_WIN32)
+        //linux
+        std::string directory_dialog(std::string save_dir){
+            static const int DIRECTORY_DIALOG_MAX_BUFFER = 16384;
+            char buffer[DIRECTORY_DIALOG_MAX_BUFFER];
+            buffer[0] = '\0';
+
+            std::string cmd = "zenity --file-selection --directory ";
+            if(save_dir.length() > 0 ){
+                cmd += "-filename="+save_dir;
+            }
+
+            FILE *output = popen(cmd.c_str(), "r");
+            if (output == nullptr)
+                throw std::runtime_error("popen() failed -- could not launch zenity!");
+            while (fgets(buffer, DIRECTORY_DIALOG_MAX_BUFFER, output) != NULL);
+            pclose(output);
+            std::string path(buffer);
+
+            path.erase(std::remove(path.begin(), path.end(), '\n'), path.end());
+
+            return path;
+
+        };
+    #else
+
+
+        std::string directory_dialog(std::string saved_path){
+            TCHAR path[MAX_PATH];
+
+            const char * path_param = saved_path.c_str();
+
+            BROWSEINFO browseInfo = { 0 };
+            browseInfo.lpszTitle  = ("Select directory");
+            browseInfo.ulFlags    = BIF_RETURNONLYFSDIRS | BIF_NEWDIALOGSTYLE | BIF_EDITBOX | BIF_BROWSEINCLUDEURLS;
+            browseInfo.lParam     = (LPARAM) path_param;
+
+            LPITEMIDLIST pidl = SHBrowseForFolder ( &browseInfo );
+
+            if( pidl == 0 ){
+                return "";
+            }else{
+                //get path
+                SHGetPathFromIDList ( pidl, path );
+
+                //free memory
+                IMalloc * imalloc = 0;
+
+                if ( SUCCEEDED( SHGetMalloc ( &imalloc )) ){
+                    imalloc->Free(pidl);
+                    imalloc->Release();
+                }
+
+                return path;
+            }
+        }
+
+    #endif
+#endif
+
+
+    void Object::inc_ref() const {
     m_ref_count++;
 }
 

--- a/src/example1.cpp
+++ b/src/example1.cpp
@@ -216,6 +216,14 @@ public:
                     { {"png", "Portable Network Graphics"}, {"txt", "Text file"} }, true) << std::endl;
         });
 
+        new Label(window, "Directory dialog", "sans-bold");
+        tools = new Widget(window);
+        tools->set_layout(new BoxLayout(Orientation::Horizontal,Alignment::Middle, 0, 6));
+        b = new Button(tools, "Browse");
+        b->set_callback([&] {
+            std::cout << "directory dialog result: " << directory_dialog() << std::endl;
+        });
+
         new Label(window, "Combo box", "sans-bold");
         new ComboBox(window, { "Combo box item 1", "Combo box item 2", "Combo box item 3"});
         new Label(window, "Check box", "sans-bold");


### PR DESCRIPTION
I've implemented a directory dialog that works on windows and on linux, 

I've used zenity for linux (implementation is practically the same as file_dialog, albeit with an extra arg)
Windows uses SHBrowseForFolder and required the including shlobj.h

