### PR TITLE
fix warnings with GCC in Windows

### DIFF
--- a/include/nanogui/common.h
+++ b/include/nanogui/common.h
@@ -88,9 +88,9 @@
 #define NANOGUI_FORCE_DISCRETE_GPU()
 #endif
 
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 #  if defined(NANOGUI_BUILD)
-/* Quench a few warnings on when compiling NanoGUI on Windows */
+/* Quench a few warnings on when compiling NanoGUI on Windows with MSVC */
 #    pragma warning(disable : 4127) // warning C4127: conditional expression is constant
 #    pragma warning(disable : 4244) // warning C4244: conversion from X to Y, possible loss of data
 #  endif

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -12,7 +12,9 @@
 #include <nanogui/screen.h>
 
 #if defined(_WIN32)
-#  define NOMINMAX
+#  ifndef NOMINMAX
+#  define NOMINMAX 1
+#  endif
 #  include <windows.h>
 #endif
 


### PR DESCRIPTION
common.h: check _MSC_VER instead of _WIN32 before adding pragma warnings
common.cpp: use #ifndef to check if NOMINMAX is already defined before
