### PR TITLE
Fix how non-integer pixel_ratios are handled.

### DIFF
--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -149,8 +149,8 @@ void Canvas::draw(NVGcontext *ctx) {
     if (m_draw_border)
         offset += Vector2i(1, 1);
 
-    fbsize = Vector2i(fbsize * pixel_ratio);
-    offset = Vector2i(offset * pixel_ratio);
+    fbsize = Vector2i(Vector2f(fbsize) * pixel_ratio);
+    offset = Vector2i(Vector2f(offset) * pixel_ratio);
 
     if (m_render_to_texture) {
         m_render_pass->resize(fbsize);

--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -197,9 +197,9 @@ void ImageView::draw_contents() {
 
     /* Ensure that 'offset' is a multiple of the pixel ratio */
     float pixel_ratio = screen()->pixel_ratio();
-    m_offset = Vector2i(Vector2i(m_offset / pixel_ratio) * pixel_ratio);
+    m_offset = (Vector2f(Vector2i(m_offset / pixel_ratio)) * pixel_ratio);
 
-    Vector2f bound1 = m_size * pixel_ratio,
+    Vector2f bound1 = Vector2f(m_size) * pixel_ratio,
              bound2 = -Vector2f(m_image->size()) * scale();
 
     if ((m_offset.x() >= bound1.x()) != (m_offset.x() < bound2.x()))


### PR DESCRIPTION
Fix how non-integer pixel_ratios are handled. e.g., a pixel ratio of 1.5 (150% in Windows) was causing problems. 
Especially noticeable with the imageview widget. This is fixed by using Vector2f where needed.

To reproduce the problem build nanogui with Visual Studio 2019 on a Windows 10 system with a scale and layout setting of 150%. You will notice that the image in the imageview widget is off.