### PR TITLE
Enable HDR on Mac

### DIFF
--- a/src/darwin.mm
+++ b/src/darwin.mm
@@ -96,7 +96,13 @@ void metal_window_init(void *nswin_, bool float_buffer) {
     layer.device = (__bridge id<MTLDevice>) s_metal_device;
     layer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
     layer.contentsScale = nswin.backingScaleFactor;
-    layer.pixelFormat = float_buffer ? MTLPixelFormatRGBA16Float : MTLPixelFormatBGRA8Unorm;
+    if (float_buffer) {
+        layer.wantsExtendedDynamicRangeContent = YES;
+        layer.pixelFormat = MTLPixelFormatRGBA16Float;
+    } else {
+        layer.wantsExtendedDynamicRangeContent = NO;
+        layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+    }
     layer.displaySyncEnabled = NO;
     layer.allowsNextDrawableTimeout = NO;
     layer.framebufferOnly = NO;


### PR DESCRIPTION
### Changes in this pull request

On Mac (with Metal), try to enable HDR when the application requests a float buffer.

### Limitations

If the current display mode does not support HDR, the system falls back to SDR. This can happen in the following circumstances:

- The hardware does not support HDR.
- The application is in windowed mode and HDR is disabled in the user's System Preferences.
- The application is in fullscreen mode. For fullscreen, the application seems to invariably get an SDR display mode, probably due to limitations of the GLFW back end (an area for future work).

### Justification for changes

The `float_buffer` parameter, in the `Screen` constructor, has the following documentation:

```
float_buffer
     *     Should NanoGUI try to allocate a floating point framebuffer? This
     *     is useful for HDR and wide-gamut displays.
```

The phrase "This is useful for HDR" implies that HDR should be enabled (if possible) when float_buffer==true.  However, in general, NanoGUI doesn't enable HDR.  This pull request is the beginning of an effort to enable HDR.

### Testing

I have tested the changes successfully on a Mac Mini (2018 model, running macOS Catalina 10.15.4) and LG CX television, which supports HDR10.
