### PR TITLE
file_dialog extension suffix fix for Windows when saving

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -375,6 +375,19 @@ std::vector<std::string> file_dialog(const std::vector<std::pair<std::string, st
         result.erase(begin(result));
     }
 
+    if (save && ofn.nFilterIndex > 0) {
+        auto ext = filetypes[ofn.nFilterIndex - 1].first;
+        if (ext != "*") {
+            ext.insert(0, ".");
+
+            auto &name = result.front();
+            if (name.size() <= ext.size() ||
+                name.compare(name.size() - ext.size(), ext.size(), ext) != 0) {
+                name.append(ext);
+            }
+        }
+    }
+
     return result;
 #else
     char buffer[FILE_DIALOG_MAX_BUFFER];


### PR DESCRIPTION
- add extension suffix if filter option selected in dialog
- don't add suffix if already present, no filter options or wildcard (\*.\*) selected