### PR TITLE
Allow uploading texture sub regions & defer mipmapping to shader bind

### DIFF
--- a/include/nanogui/texture.h
+++ b/include/nanogui/texture.h
@@ -118,7 +118,7 @@ public:
             WrapMode wrap_mode = WrapMode::ClampToEdge,
             uint8_t samples = 1,
             uint8_t flags = (uint8_t) TextureFlags::ShaderRead,
-            bool manual_mipmapping = false);
+            bool mipmap_manual = false);
 
     /// Load an image from the given file using stb-image
     Texture(const std::string &filename,
@@ -195,7 +195,7 @@ protected:
     uint8_t m_samples;
     uint8_t m_flags;
     Vector2i m_size;
-    bool m_manual_mipmapping;
+    bool m_mipmap_manual;
 
     #if defined(NANOGUI_USE_OPENGL) || defined(NANOGUI_USE_GLES)
         uint32_t m_texture_handle = 0;

--- a/include/nanogui/texture.h
+++ b/include/nanogui/texture.h
@@ -117,7 +117,8 @@ public:
             InterpolationMode mag_interpolation_mode = InterpolationMode::Bilinear,
             WrapMode wrap_mode = WrapMode::ClampToEdge,
             uint8_t samples = 1,
-            uint8_t flags = (uint8_t) TextureFlags::ShaderRead);
+            uint8_t flags = (uint8_t) TextureFlags::ShaderRead,
+            bool manual_mipmapping = false);
 
     /// Load an image from the given file using stb-image
     Texture(const std::string &filename,
@@ -158,11 +159,17 @@ public:
     /// Upload packed pixel data from the CPU to the GPU
     void upload(const uint8_t *data);
 
+    /// Upload packed pixel data to a rectangular sub-region of the texture from the CPU to the GPU
+    void upload_sub_region(const uint8_t *data, const Vector2i& origin, const Vector2i& size);
+
     /// Download packed pixel data from the GPU to the CPU
     void download(uint8_t *data);
 
     /// Resize the texture (discards the current contents)
     void resize(const Vector2i &size);
+
+    /// Generates the mipmap. Done automatically upon upload if manual mipmapping is disabled.
+    void generate_mipmap();
 
 #if defined(NANOGUI_USE_OPENGL) || defined(NANOGUI_USE_GLES)
     uint32_t texture_handle() const { return m_texture_handle; }
@@ -188,6 +195,7 @@ protected:
     uint8_t m_samples;
     uint8_t m_flags;
     Vector2i m_size;
+    bool m_manual_mipmapping;
 
     #if defined(NANOGUI_USE_OPENGL) || defined(NANOGUI_USE_GLES)
         uint32_t m_texture_handle = 0;

--- a/src/python/py_doc.h
+++ b/src/python/py_doc.h
@@ -2805,6 +2805,10 @@ static const char *__doc_nanogui_Texture_texture_handle = R"doc()doc";
 
 static const char *__doc_nanogui_Texture_upload = R"doc(Upload packed pixel data from the CPU to the GPU)doc";
 
+static const char *__doc_nanogui_Texture_upload_origin = R"doc(Upload packed pixel data to a rectangular sub-region of the texture from the CPU to the GPU)doc";
+
+static const char *__doc_nanogui_Texture_generate_mipmap = R"doc(Generates the mipmap. Done automatically upon upload if manual mipmapping is disabled)doc";
+
 static const char *__doc_nanogui_Texture_wrap_mode = R"doc(Return the wrap mode)doc";
 
 static const char *__doc_nanogui_Theme = R"doc()doc";

--- a/src/python/render.cpp
+++ b/src/python/render.cpp
@@ -189,7 +189,7 @@ void register_render(py::module &m) {
              "mag_interpolation_mode"_a = InterpolationMode::Bilinear,
              "wrap_mode"_a = WrapMode::ClampToEdge, "samples"_a = 1,
              "flags"_a = (uint8_t) TextureFlags::ShaderRead,
-             "manual_mipmapping"_a = false)
+             "mipmap_manual"_a = false)
         .def(py::init<const std::string &, InterpolationMode, InterpolationMode, WrapMode>(),
              D(Texture, Texture, 2), "filename"_a,
              "min_interpolation_mode"_a = InterpolationMode::Bilinear,

--- a/src/python/render.cpp
+++ b/src/python/render.cpp
@@ -110,6 +110,30 @@ static void texture_upload(Texture &texture, py::array array) {
     texture.upload((const uint8_t *) array.data());
 }
 
+static void texture_upload_sub_region(Texture &texture, py::array array, const Vector2i &origin) {
+    size_t n_channels = array.ndim() == 3 ? array.shape(2) : 1;
+    VariableType dtype         = dtype_to_enoki(array.dtype()),
+                 dtype_texture = (VariableType) texture.component_format();
+
+    if (array.ndim() != 2 && array.ndim() != 3)
+        throw std::runtime_error("Texture::upload_sub_region(): expected a 2 or 3-dimensional array!");
+    else if (array.shape(0) + origin.x() > texture.size().y() ||
+             array.shape(1) + origin.y() > texture.size().x())
+        throw std::runtime_error("Texture::upload_sub_region(): bounds exceed the size of the texture!");
+    else if (n_channels != texture.channels())
+        throw std::runtime_error(
+            std::string("Texture::upload_sub_region(): number of color channels in array (") +
+            std::to_string(n_channels) + ") does not match the texture (" +
+            std::to_string(texture.channels()) + ")!");
+    else if (dtype != dtype_texture)
+        throw std::runtime_error(
+            std::string("Texture::upload_sub_region(): dtype of array (") +
+            type_name(dtype) + ") does not match the texture (" +
+            type_name(dtype_texture) + ")!");
+
+    texture.upload_sub_region((const uint8_t *) array.data(), origin, {(int32_t) array.shape(0), (int32_t) array.shape(1)});
+}
+
 void register_render(py::module &m) {
     using PixelFormat       = Texture::PixelFormat;
     using ComponentFormat   = Texture::ComponentFormat;
@@ -159,12 +183,13 @@ void register_render(py::module &m) {
 
     texture
         .def(py::init<PixelFormat, ComponentFormat, const Vector2i &,
-                      InterpolationMode, InterpolationMode, WrapMode, uint8_t, uint8_t>(),
+                      InterpolationMode, InterpolationMode, WrapMode, uint8_t, uint8_t, bool>(),
              D(Texture, Texture), "pixel_format"_a, "component_format"_a, "size"_a,
              "min_interpolation_mode"_a = InterpolationMode::Bilinear,
              "mag_interpolation_mode"_a = InterpolationMode::Bilinear,
              "wrap_mode"_a = WrapMode::ClampToEdge, "samples"_a = 1,
-             "flags"_a = (uint8_t) TextureFlags::ShaderRead)
+             "flags"_a = (uint8_t) TextureFlags::ShaderRead,
+             "manual_mipmapping"_a = false)
         .def(py::init<const std::string &, InterpolationMode, InterpolationMode, WrapMode>(),
              D(Texture, Texture, 2), "filename"_a,
              "min_interpolation_mode"_a = InterpolationMode::Bilinear,
@@ -182,6 +207,8 @@ void register_render(py::module &m) {
         .def("channels", &Texture::channels, D(Texture, channels))
         .def("download", &texture_download, D(Texture, download))
         .def("upload", &texture_upload, D(Texture, upload))
+        .def("upload_sub_region", &texture_upload_sub_region, D(Texture, upload, origin))
+        .def("generate_mipmap", &Texture::generate_mipmap, D(Texture, generate_mipmap))
         .def("resize", &Texture::resize, D(Texture, resize))
 #if defined(NANOGUI_USE_OPENGL) || defined(NANOGUI_USE_GLES)
         .def("texture_handle", &Texture::texture_handle)

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -12,7 +12,7 @@ Texture::Texture(PixelFormat pixel_format,
                  WrapMode wrap_mode,
                  uint8_t samples,
                  uint8_t flags,
-                 bool manual_mipmapping)
+                 bool mipmap_manual)
     : m_pixel_format(pixel_format),
       m_component_format(component_format),
       m_min_interpolation_mode(min_interpolation_mode),
@@ -21,7 +21,7 @@ Texture::Texture(PixelFormat pixel_format,
       m_samples(samples),
       m_flags(flags),
       m_size(size),
-      m_manual_mipmapping(manual_mipmapping) {
+      m_mipmap_manual(mipmap_manual) {
 
     init();
 }
@@ -36,7 +36,7 @@ Texture::Texture(const std::string &filename,
       m_wrap_mode(wrap_mode),
       m_samples(1),
       m_flags(TextureFlags::ShaderRead),
-      m_manual_mipmapping(false) {
+      m_mipmap_manual(false) {
     int n = 0;
     using Holder = std::unique_ptr<uint8_t[], void(*)(void*)>;
     Holder texture_data(stbi_load(filename.c_str(), &m_size.x(), &m_size.y(), &n, 0),

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -11,7 +11,8 @@ Texture::Texture(PixelFormat pixel_format,
                  InterpolationMode mag_interpolation_mode,
                  WrapMode wrap_mode,
                  uint8_t samples,
-                 uint8_t flags)
+                 uint8_t flags,
+                 bool manual_mipmapping)
     : m_pixel_format(pixel_format),
       m_component_format(component_format),
       m_min_interpolation_mode(min_interpolation_mode),
@@ -19,7 +20,8 @@ Texture::Texture(PixelFormat pixel_format,
       m_wrap_mode(wrap_mode),
       m_samples(samples),
       m_flags(flags),
-      m_size(size) {
+      m_size(size),
+      m_manual_mipmapping(manual_mipmapping) {
 
     init();
 }
@@ -33,7 +35,8 @@ Texture::Texture(const std::string &filename,
       m_mag_interpolation_mode(mag_interpolation_mode),
       m_wrap_mode(wrap_mode),
       m_samples(1),
-      m_flags(TextureFlags::ShaderRead) {
+      m_flags(TextureFlags::ShaderRead),
+      m_manual_mipmapping(false) {
     int n = 0;
     using Holder = std::unique_ptr<uint8_t[], void(*)(void*)>;
     Holder texture_data(stbi_load(filename.c_str(), &m_size.x(), &m_size.y(), &n, 0),

--- a/src/texture_gl.cpp
+++ b/src/texture_gl.cpp
@@ -177,9 +177,9 @@ void Texture::upload(const uint8_t *data) {
                          (GLsizei) m_size.y(), 0, pixel_format_gl, component_format_gl, data));
 #endif
 
-        if (m_min_interpolation_mode == InterpolationMode::Trilinear ||
-            m_mag_interpolation_mode == InterpolationMode::Trilinear)
-            CHK(glGenerateMipmap(tex_mode));
+        if (!m_manual_mipmapping && (m_min_interpolation_mode == InterpolationMode::Trilinear ||
+            m_mag_interpolation_mode == InterpolationMode::Trilinear))
+            generate_mipmap();
     } else {
 #if defined(NANOGUI_USE_OPENGL)
         CHK(glBindRenderbuffer(GL_RENDERBUFFER, m_renderbuffer_handle));
@@ -194,6 +194,48 @@ void Texture::upload(const uint8_t *data) {
                                   (GLsizei) m_size.x(), (GLsizei) m_size.y()));
 #endif
     }
+}
+
+void Texture::upload_sub_region(const uint8_t *data, const Vector2i& origin, const Vector2i& size) {
+    if (m_samples > 1 && data != nullptr)
+        throw std::runtime_error("Texture::upload_sub_region(): only implemented for samples=1!");
+
+    GLenum pixel_format_gl,
+           component_format_gl,
+           internal_format_gl;
+
+    gl_map_texture_format(m_pixel_format,
+                          m_component_format,
+                          pixel_format_gl,
+                          component_format_gl,
+                          internal_format_gl);
+
+    if (m_texture_handle == 0)
+        throw std::runtime_error("Texture::upload_sub_region(): not implemented for render targets!");
+
+    if (origin.x() + size.x() > m_size.x() || origin.y() + size.y() > m_size.y())
+        throw std::runtime_error("Texture::upload_sub_region(): out of bounds!");
+
+    GLenum tex_mode = m_samples > 1 ? GL_TEXTURE_2D_MULTISAMPLE : GL_TEXTURE_2D;
+    CHK(glBindTexture(tex_mode, m_texture_handle));
+
+    if (data)
+        CHK(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
+
+#if defined(NANOGUI_USE_OPENGL)
+    if (data) {
+        CHK(glPixelStorei(GL_UNPACK_ROW_LENGTH, 0));
+        CHK(glPixelStorei(GL_UNPACK_SKIP_ROWS, 0));
+        CHK(glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0));
+    }
+#endif
+
+    CHK(glTexSubImage2D(tex_mode, 0, (GLsizei) origin.x(), (GLsizei) origin.y(), (GLsizei) size.x(),
+                        (GLsizei) size.y(), pixel_format_gl, component_format_gl, data));
+
+    if (!m_manual_mipmapping && (m_min_interpolation_mode == InterpolationMode::Trilinear ||
+        m_mag_interpolation_mode == InterpolationMode::Trilinear))
+        generate_mipmap();
 }
 
 void Texture::download(uint8_t *data) {
@@ -241,6 +283,12 @@ void Texture::resize(const Vector2i &size) {
         return;
     m_size = size;
     upload(nullptr);
+}
+
+void Texture::generate_mipmap() {
+    GLenum tex_mode = m_samples > 1 ? GL_TEXTURE_2D_MULTISAMPLE : GL_TEXTURE_2D;
+    CHK(glBindTexture(tex_mode, m_texture_handle));
+    CHK(glGenerateMipmap(tex_mode));
 }
 
 static void gl_map_texture_format(Texture::PixelFormat &pixel_format,

--- a/src/texture_gl.cpp
+++ b/src/texture_gl.cpp
@@ -177,7 +177,7 @@ void Texture::upload(const uint8_t *data) {
                          (GLsizei) m_size.y(), 0, pixel_format_gl, component_format_gl, data));
 #endif
 
-        if (!m_manual_mipmapping && (m_min_interpolation_mode == InterpolationMode::Trilinear ||
+        if (!m_mipmap_manual && (m_min_interpolation_mode == InterpolationMode::Trilinear ||
             m_mag_interpolation_mode == InterpolationMode::Trilinear))
             generate_mipmap();
     } else {
@@ -233,7 +233,7 @@ void Texture::upload_sub_region(const uint8_t *data, const Vector2i& origin, con
     CHK(glTexSubImage2D(tex_mode, 0, (GLsizei) origin.x(), (GLsizei) origin.y(), (GLsizei) size.x(),
                         (GLsizei) size.y(), pixel_format_gl, component_format_gl, data));
 
-    if (!m_manual_mipmapping && (m_min_interpolation_mode == InterpolationMode::Trilinear ||
+    if (!m_mipmap_manual && (m_min_interpolation_mode == InterpolationMode::Trilinear ||
         m_mag_interpolation_mode == InterpolationMode::Trilinear))
         generate_mipmap();
 }

--- a/src/texture_metal.mm
+++ b/src/texture_metal.mm
@@ -82,7 +82,7 @@ void Texture::upload(const uint8_t *data) {
     [command_buffer commit];
     [command_buffer waitUntilCompleted];
 
-    if (!m_manual_mipmapping && m_min_interpolation_mode == InterpolationMode::Trilinear)
+    if (!m_mipmap_manual && m_min_interpolation_mode == InterpolationMode::Trilinear)
         generate_mipmap();
 }
 
@@ -121,7 +121,7 @@ void Texture::upload_sub_region(const uint8_t *data, const Vector2i& origin, con
     [command_buffer commit];
     [command_buffer waitUntilCompleted];
 
-    if (!m_manual_mipmapping && m_min_interpolation_mode == InterpolationMode::Trilinear)
+    if (!m_mipmap_manual && m_min_interpolation_mode == InterpolationMode::Trilinear)
         generate_mipmap();
 }
 

--- a/src/texture_metal.mm
+++ b/src/texture_metal.mm
@@ -78,12 +78,51 @@ void Texture::upload(const uint8_t *data) {
                 destinationLevel: 0
                destinationOrigin: MTLOriginMake(0, 0, 0)];
 
-    if (m_min_interpolation_mode == InterpolationMode::Trilinear)
-        [command_encoder generateMipmapsForTexture: texture];
+    [command_encoder endEncoding];
+    [command_buffer commit];
+    [command_buffer waitUntilCompleted];
+
+    if (!m_manual_mipmapping && m_min_interpolation_mode == InterpolationMode::Trilinear)
+        generate_mipmap();
+}
+
+void Texture::upload_sub_region(const uint8_t *data, const Vector2i& origin, const Vector2i& size) {
+    id<MTLTexture> texture = (__bridge id<MTLTexture>) m_texture_handle;
+
+    MTLTextureDescriptor *texture_desc =
+        [MTLTextureDescriptor texture2DDescriptorWithPixelFormat: texture.pixelFormat
+                                                           width: (NSUInteger) size.x()
+                                                          height: (NSUInteger) size.y()
+                                                       mipmapped: NO];
+
+    id<MTLDevice> device = (__bridge id<MTLDevice>) metal_device();
+    id<MTLCommandQueue> command_queue = (__bridge id<MTLCommandQueue>) metal_command_queue();
+    id<MTLCommandBuffer> command_buffer = [command_queue commandBuffer];
+    id<MTLBlitCommandEncoder> command_encoder = [command_buffer blitCommandEncoder];
+    id<MTLTexture> temp_texture = [device newTextureWithDescriptor:texture_desc];
+
+    [temp_texture replaceRegion: MTLRegionMake2D(0, 0, (NSUInteger) size.x(), (NSUInteger) size.y())
+                  mipmapLevel: 0
+                  withBytes: data
+                  bytesPerRow: (NSUInteger) (bytes_per_pixel() * size.x())];
+
+    [command_encoder
+                 copyFromTexture: temp_texture
+                     sourceSlice: 0
+                     sourceLevel: 0
+                    sourceOrigin: MTLOriginMake(0, 0, 0)
+                      sourceSize: MTLSizeMake((NSUInteger) size.x(), (NSUInteger) size.y(), 1)
+                       toTexture: texture
+                destinationSlice: 0
+                destinationLevel: 0
+               destinationOrigin: MTLOriginMake((NSUInteger) origin.x(), (NSUInteger) origin.y(), 0)];
 
     [command_encoder endEncoding];
     [command_buffer commit];
     [command_buffer waitUntilCompleted];
+
+    if (!m_manual_mipmapping && m_min_interpolation_mode == InterpolationMode::Trilinear)
+        generate_mipmap();
 }
 
 void Texture::download(uint8_t *data) {
@@ -260,6 +299,18 @@ void Texture::resize(const Vector2i &size) {
 
     id<MTLTexture> texture = [device newTextureWithDescriptor:texture_desc];
     m_texture_handle = (__bridge_retained void *) texture;
+}
+
+void Texture::generate_mipmap() {
+    id<MTLTexture> texture = (__bridge id<MTLTexture>) m_texture_handle;
+    id<MTLCommandQueue> command_queue = (__bridge id<MTLCommandQueue>) metal_command_queue();
+    id<MTLCommandBuffer> command_buffer = [command_queue commandBuffer];
+    id<MTLBlitCommandEncoder> command_encoder = [command_buffer blitCommandEncoder];
+
+    [command_encoder generateMipmapsForTexture: texture];
+    [command_encoder endEncoding];
+    [command_buffer commit];
+    [command_buffer waitUntilCompleted];
 }
 
 NAMESPACE_END(nanogui)


### PR DESCRIPTION
- Adds the ability to upload texture sub-regions (also exposed to python)
- Adds the ability to lazily re-compute mipmaps whenever the texture is assigned to a shader via `set_texture` or by manually calling `Texture::update_mipmap` (off by default & not exposed to python for now)

Used in tev to allow remote control of the content that is being displayed.