### PR TITLE
Dynamic content scaling

### DIFF
--- a/include/nanogui/metal.h
+++ b/include/nanogui/metal.h
@@ -40,6 +40,9 @@ extern NANOGUI_EXPORT void metal_window_init(void *nswin, bool float_buffer);
 /// Set size of the drawable underlying an NSWindow
 extern NANOGUI_EXPORT void metal_window_set_size(void *nswin, const Vector2i &size);
 
+/// Set content scale of the drawable underlying an NSWindow
+extern NANOGUI_EXPORT void metal_window_set_content_scale(void *nswin, float scale);
+
 /// Return the CAMetalLayer associated with a given NSWindow
 extern NANOGUI_EXPORT void *metal_window_layer(void *nswin);
 

--- a/src/darwin.mm
+++ b/src/darwin.mm
@@ -4,6 +4,7 @@
 #if defined(NANOGUI_USE_METAL)
 #  import <Metal/Metal.h>
 #  import <QuartzCore/CAMetalLayer.h>
+#  import <QuartzCore/CATransaction.h>
 #endif
 
 #if !defined(MAC_OS_X_VERSION_10_15) || \
@@ -150,6 +151,20 @@ void metal_window_set_size(void *nswin_, const Vector2i &size) {
     NSWindow *nswin = (__bridge NSWindow *) nswin_;
     CAMetalLayer *layer = (CAMetalLayer *) nswin.contentView.layer;
     layer.drawableSize = CGSizeMake(size.x(), size.y());
+}
+
+void metal_window_set_content_scale(void *nswin_, float scale) {
+    NSWindow *nswin = (__bridge NSWindow *) nswin_;
+    CAMetalLayer *layer = (CAMetalLayer *) nswin.contentView.layer;
+
+    float old_scale = layer.contentsScale;
+    if (old_scale != scale) {
+        [CATransaction begin];
+        [CATransaction setValue:(id)kCFBooleanTrue
+                        forKey:kCATransactionDisableActions];
+        layer.contentsScale = scale;
+        [CATransaction commit];
+    }
 }
 
 void* metal_window_layer(void *nswin_) {

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -236,6 +236,7 @@ Screen::Screen(const Vector2i &size, const std::string &caption, bool resizable,
 
     glfwWindowHint(GLFW_VISIBLE, GL_FALSE);
     glfwWindowHint(GLFW_RESIZABLE, resizable ? GL_TRUE : GL_FALSE);
+    glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
 
     for (int i = 0; i < 2; ++i) {
         if (fullscreen) {
@@ -424,6 +425,19 @@ Screen::Screen(const Vector2i &size, const std::string &caption, bool resizable,
             s->focus_event(focused != 0);
         }
     );
+
+    glfwSetWindowContentScaleCallback(m_glfw_window,
+        [](GLFWwindow* w, float x_scale, float y_scale) {
+            auto it = __nanogui_screens.find(w);
+            if (it == __nanogui_screens.end())
+                return;
+            Screen* s = it->second;
+
+            s->m_pixel_ratio = get_pixel_ratio(w);
+            s->resize_callback_event(s->m_size.x(), s->m_size.y());
+        }
+    );
+
     initialize(m_glfw_window, true);
 
 #if defined(NANOGUI_USE_METAL)

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -76,54 +76,10 @@ static bool glad_initialized = false;
 static float get_pixel_ratio(GLFWwindow *window) {
 #if defined(EMSCRIPTEN)
     return emscripten_get_device_pixel_ratio();
-#elif defined(_WIN32)
-    HWND hwnd = glfwGetWin32Window(window);
-    HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-    /* The following function only exists on Windows 8.1+, but we don't want to make that a dependency */
-    static HRESULT (WINAPI *GetDpiForMonitor_)(HMONITOR, UINT, UINT*, UINT*) = nullptr;
-    static bool GetDpiForMonitor_tried = false;
-
-    if (!GetDpiForMonitor_tried) {
-        auto shcore = LoadLibrary(TEXT("shcore"));
-        if (shcore)
-            GetDpiForMonitor_ = (decltype(GetDpiForMonitor_)) GetProcAddress(shcore, "GetDpiForMonitor");
-        GetDpiForMonitor_tried = true;
-    }
-
-    if (GetDpiForMonitor_) {
-        uint32_t dpi_x, dpi_y;
-        if (GetDpiForMonitor_(monitor, 0 /* effective DPI */, &dpi_x, &dpi_y) == S_OK)
-            return dpi_x / 96.0;
-    }
-    return 1.f;
-#elif defined(__linux__)
-    (void) window;
-
-    float ratio = 1.0f;
-    FILE *fp;
-    /* Try to read the pixel ratio from KDEs config */
-    auto currentDesktop = std::getenv("XDG_CURRENT_DESKTOP");
-    if (currentDesktop && currentDesktop == std::string("KDE")) {
-        fp = popen("kreadconfig5 --group KScreen --key ScaleFactor", "r");
-        if (!fp)
-            return 1;
-
-        if (fscanf(fp, "%f", &ratio) != 1)
-            return 1;
-    } else {
-        /* Try to read the pixel ratio from GTK */
-        fp = popen("gsettings get org.gnome.desktop.interface scaling-factor", "r");
-        if (!fp)
-            return 1;
-
-        int ratioInt = 1;
-        if (fscanf(fp, "uint32 %i", &ratioInt) != 1)
-            return 1;
-        ratio = ratioInt;
-    }
-    if (pclose(fp) != 0)
-        return 1;
-    return ratio >= 1 ? ratio : 1;
+#elif defined(_WIN32) or defined(__linux__)
+    float xscale, yscale;
+    glfwGetWindowContentScale(window, &xscale, &yscale);
+    return xscale;
 #else
     Vector2i fb_size, size;
     glfwGetFramebufferSize(window, &fb_size[0], &fb_size[1]);
@@ -427,7 +383,7 @@ Screen::Screen(const Vector2i &size, const std::string &caption, bool resizable,
     );
 
     glfwSetWindowContentScaleCallback(m_glfw_window,
-        [](GLFWwindow* w, float x_scale, float y_scale) {
+        [](GLFWwindow* w, float, float) {
             auto it = __nanogui_screens.find(w);
             if (it == __nanogui_screens.end())
                 return;

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -76,15 +76,10 @@ static bool glad_initialized = false;
 static float get_pixel_ratio(GLFWwindow *window) {
 #if defined(EMSCRIPTEN)
     return emscripten_get_device_pixel_ratio();
-#elif defined(_WIN32) or defined(__linux__)
+#else
     float xscale, yscale;
     glfwGetWindowContentScale(window, &xscale, &yscale);
     return xscale;
-#else
-    Vector2i fb_size, size;
-    glfwGetFramebufferSize(window, &fb_size[0], &fb_size[1]);
-    glfwGetWindowSize(window, &size[0], &size[1]);
-    return (float) fb_size[0] / (float) size[0];
 #endif
 }
 
@@ -581,6 +576,9 @@ void Screen::draw_setup() {
     /* Recompute pixel ratio on OSX */
     if (m_size[0])
         m_pixel_ratio = (float) m_fbsize[0] / (float) m_size[0];
+#if defined(NANOGUI_USE_METAL)
+    metal_window_set_content_scale(nswin, m_pixel_ratio);
+#endif
 #endif
 
 #if defined(NANOGUI_USE_OPENGL) || defined(NANOGUI_USE_GLES)
@@ -861,6 +859,7 @@ void Screen::resize_callback_event(int, int) {
 #if defined(EMSCRIPTEN)
     return;
 #endif
+
     Vector2i fb_size, size;
     glfwGetFramebufferSize(m_glfw_window, &fb_size[0], &fb_size[1]);
     glfwGetWindowSize(m_glfw_window, &size[0], &size[1]);


### PR DESCRIPTION
Additions:
- Linux: Makes static content scaling work on GNOME. (Previously only worked in KDE. Unfortunately I could not test whether it _still_ works in KDE, so feedback from somebody using it would be appreciated.)
- Windows & macOS (Metal): Makes _dynamic_ content scaling work (see https://github.com/Tom94/tev/issues/135)

Overall, the code actually got simpler due to GLFW's recent additions. :)

Known to be still broken:
- No dynamic content scaling on GNOME (only uses scaling from startup). KDE TBD