### PR TITLE
macOS: don't change the working directory upon GLFW init

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -52,6 +52,7 @@ void init() {
 
     #if defined(__APPLE__)
         disable_saved_application_state_osx();
+        glfwInitHint(GLFW_COCOA_CHDIR_RESOURCES, GLFW_FALSE);
     #endif
 
     glfwSetErrorCallback(


### PR DESCRIPTION
Resolves https://github.com/Tom94/tev/pull/138

I wonder what they were thinking making this the default behavior. I have a hard time finding justification in Google.

The function seems to have been first introduced 9 years ago as a compile-time switch: https://github.com/glfw/glfw/commit/6333a5caaf92ee76f5a502c3b406c2f7868d913e

