### PR TITLE
find_package glfw when NANOGUI_BUILD_GLFW=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,7 +497,14 @@ if (EXISTS /opt/vc/include)
   target_include_directories(nanogui PUBLIC /opt/vc/include)
 endif()
 
+# Find glfw if nanogui is not compiling it internally.
+if (NOT NANOGUI_BUILD_GLFW)
+  find_package(glfw3 CONFIG REQUIRED)
+  target_link_libraries(nanogui PUBLIC glfw)
+endif()
+
 if (NANOGUI_INSTALL)
+  include(GNUInstallDirs)
   install(TARGETS nanogui
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -522,6 +529,7 @@ if (NANOGUI_INSTALL)
 
   set(NANOGUI_CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATAROOTDIR}/cmake/nanogui")
 
+  include(CMakePackageConfigHelpers)
   configure_package_config_file(
     resources/nanoguiConfig.cmake.in nanoguiConfig.cmake
     INSTALL_DESTINATION ${NANOGUI_CMAKECONFIG_INSTALL_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -427,6 +427,11 @@ add_library(nanogui ${NANOGUI_LIBRARY_TYPE}
   include/nanogui/nanogui.h
 )
 
+# Defines various CMAKE_INSTALL_* variables used below in $<INSTALL_INTERFACE>.
+if (NANOGUI_INSTALL)
+  include(GNUInstallDirs)
+endif()
+
 target_compile_definitions(nanogui
   PUBLIC
     ${NANOGUI_BACKEND_DEFS}
@@ -504,7 +509,6 @@ if (NOT NANOGUI_BUILD_GLFW)
 endif()
 
 if (NANOGUI_INSTALL)
-  include(GNUInstallDirs)
   install(TARGETS nanogui
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/resources/nanoguiConfig.cmake.in
+++ b/resources/nanoguiConfig.cmake.in
@@ -8,6 +8,13 @@ check_required_components(nanogui)
 
 include("${CMAKE_CURRENT_LIST_DIR}/nanoguiTargets.cmake")
 
+# Find glfw if nanogui did not compile it internally.
+if (NOT @NANOGUI_BUILD_GLFW@)
+  include(CMakeFindDependencyMacro)
+  find_dependency(glfw3 CONFIG)
+  target_link_libraries(nanogui INTERFACE glfw)
+endif()
+
 if(NOT nanogui_FIND_QUIETLY)
   message(STATUS "Found nanogui: ${nanogui_INCLUDE_DIR} (found version \"${nanogui_VERSION}\" ${nanogui_VERSION_TYPE})")
 endif()


### PR DESCRIPTION
Also include some missing CMake utilities for install logic.

I think those files get included into the scope via the GLFW cmake build somehow which would explain why this went unnoticed :slightly_smiling_face:

Fixes #101.

Install tree for me with external glfw looked like this:

```console
$ /tmp/nanogui/
├── include
│   ├── nanogui
│   └── nanovg
├── lib64
└── share
    └── cmake
        └── nanogui

7 directories
```