### PR TITLE
Fixed M1 detection in cmake 3.22.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ endif()
 
 if (MSVC)
   set(NANOGUI_NATIVE_FLAGS_DEFAULT "")
-elseif (APPLE AND CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+elseif (APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
   # Apple M1 compatibility
   set(NANOGUI_NATIVE_FLAGS_DEFAULT "-mcpu=apple-a12")
 else()


### PR DESCRIPTION
`CMAKE_OSX_ARCHITECTURES` empty brings cmake into the default x86_64 nehalem option set. `if(APPLE)` test in the CMakeLists.txt results true so using either `OSX_ARCHITECTURES` or `CMAKE_SYSTEM_PROCESSOR` should be equivalent.

Tested under MacOS Monterey 12.1, Xcode 13.2.1 (13C100)
cmake version 3.22.1
Homebrew 3.3.13
Homebrew/homebrew-core (git revision a3a67a0a95c; last commit 2022-02-04)
Homebrew/homebrew-cask (git revision 71a2e51b77; last commit 2022-02-04)
-- The CXX compiler identification is AppleClang 13.0.0.13000029
-- The C compiler identification is AppleClang 13.0.0.13000029