### PR TITLE
Enable input of non ascii characters for TextBox

### DIFF
--- a/include/nanogui/common.h
+++ b/include/nanogui/common.h
@@ -323,7 +323,7 @@ extern NANOGUI_EXPORT void chdir_to_bundle_parent();
  * \brief Convert a single UTF32 character code to UTF8.
  *
  * \rst
- * NanoGUI uses this to convert the icon character codes
+ * NanoGUI uses this to convert the input and the icon character codes
  * defined in :ref:`file_nanogui_entypo.h`.
  * \endrst
  *
@@ -331,8 +331,35 @@ extern NANOGUI_EXPORT void chdir_to_bundle_parent();
  *     The UTF32 character to be converted.
  */
 extern NANOGUI_EXPORT std::string utf8(uint32_t c);
+
+/**
+ * \brief Return the number of bytes which consist an UTF8 character.
+ *
+ * \param c
+ *     The first byte of a UTF8 character.
+ */
 extern NANOGUI_EXPORT size_t utf8_charcount(char c);
+
+/**
+ * \brief Count the number of characters in an UTF8 string.
+ *
+ * \param str
+ *     The UTF8 string.
+ */
 extern NANOGUI_EXPORT size_t utf8_glyphlen(const std::string& str);
+
+/**
+ * \brief Convert the character position to the position in an UTF8 string.
+ *
+ * A character position is the position counted by character,
+ * which corresponds to one to four bytes in UTF8.
+ *
+ * \param str
+ *     The UTF8 string to find the position in.
+ *
+ * \param glyph_pos
+ *     The character position.
+ */
 extern NANOGUI_EXPORT size_t utf8_strpos(const std::string& str, size_t glyph_pos);
 
 /// Load a directory of PNG images and upload them to the GPU (suitable for use with ImagePanel)

--- a/include/nanogui/common.h
+++ b/include/nanogui/common.h
@@ -331,6 +331,9 @@ extern NANOGUI_EXPORT void chdir_to_bundle_parent();
  *     The UTF32 character to be converted.
  */
 extern NANOGUI_EXPORT std::string utf8(uint32_t c);
+extern NANOGUI_EXPORT size_t utf8_charcount(char c);
+extern NANOGUI_EXPORT size_t utf8_glyphlen(const std::string& str);
+extern NANOGUI_EXPORT size_t utf8_strpos(const std::string& str, size_t glyph_pos);
 
 /// Load a directory of PNG images and upload them to the GPU (suitable for use with ImagePanel)
 extern NANOGUI_EXPORT std::vector<std::pair<int, std::string>>

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -253,6 +253,40 @@ std::string utf8(uint32_t c) {
     return std::string(seq, seq + n);
 }
 
+size_t utf8_charcount(char c) {
+    if (0 <= uint8_t(c) && uint8_t(c) < 0x80)
+        return 1;
+    if (0xc2 <= uint8_t(c) && uint8_t(c) < 0xe0)
+        return 2;
+    if (0xe0 <= uint8_t(c) && uint8_t(c) < 0xf0)
+        return 3;
+    if (0xf0 <= uint8_t(c) && uint8_t(c) < 0xf8)
+        return 4;
+    return 0;
+}
+
+size_t utf8_glyphlen(const std::string& str) {
+    size_t len = 0, pos = 0;
+    while (pos < str.length()) {
+        len++;
+        pos += utf8_charcount(str[pos]);
+    }
+    return len;
+}
+
+size_t utf8_strpos(const std::string& str, size_t glyph_pos) {
+    size_t str_pos = 0, tmp_glyph_pos = 0;
+    while (tmp_glyph_pos < glyph_pos) {
+        str_pos += utf8_charcount(str[str_pos]);
+        tmp_glyph_pos++;
+    }
+    return str_pos;
+}
+
+bool is_utf8_later_byte(char c) {
+    return 0x80 <= uint8_t(c) && uint8_t(c) < 0xc0;
+}
+
 int __nanogui_get_image(NVGcontext *ctx, const std::string &name, uint8_t *data, uint32_t size) {
     static std::map<std::string, int> icon_cache;
     auto it = icon_cache.find(name);

--- a/src/textbox.cpp
+++ b/src/textbox.cpp
@@ -302,7 +302,7 @@ bool TextBox::mouse_button_event(const Vector2i &p, int button, bool down,
             if (time - m_last_click < 0.25) {
                 /* Double-click: select all text */
                 m_selection_pos = 0;
-                m_cursor_pos = (int) m_value_temp.size();
+                m_cursor_pos = (int) utf8_glyphlen(m_value_temp);
                 m_mouse_down_pos = Vector2i(-1, -1);
             }
             m_last_click = time;
@@ -366,6 +366,21 @@ bool TextBox::mouse_drag_event(const Vector2i &p, const Vector2i &/* rel */,
 }
 
 bool TextBox::focus_event(bool focused) {
+    /*
+     * Workaround to allow input from input method (when using Japanese, etc.)
+     * When using IM, an application switch between nanogui application and
+     * IM occurs. When back from IM, focus_event() is invoked without mouse
+     * being pressed on the Screen. When such event is detected, leave focuses
+     * as it was before the application switch to the IM.
+     */
+    Widget* p = this;
+    while(p->parent() != nullptr)
+        p = p->parent();
+    GLFWwindow* w = dynamic_cast<Screen*>(p)->glfw_window();
+    int mouse_button = glfwGetMouseButton(w, GLFW_MOUSE_BUTTON_LEFT);
+    if (mouse_button == GLFW_RELEASE)
+        return m_focused;
+
     Widget::focus_event(focused);
 
     std::string backup = m_value;
@@ -420,7 +435,7 @@ bool TextBox::keyboard_event(int key, int /* scancode */, int action, int modifi
                     m_selection_pos = -1;
                 }
 
-                if (m_cursor_pos < (int) m_value_temp.length())
+                if (m_cursor_pos < (int) utf8_glyphlen(m_value_temp))
                     m_cursor_pos++;
             } else if (key == GLFW_KEY_HOME) {
                 if (modifiers == GLFW_MOD_SHIFT) {
@@ -439,24 +454,27 @@ bool TextBox::keyboard_event(int key, int /* scancode */, int action, int modifi
                     m_selection_pos = -1;
                 }
 
-                m_cursor_pos = (int) m_value_temp.size();
+                m_cursor_pos = (int) utf8_glyphlen(m_value_temp);
             } else if (key == GLFW_KEY_BACKSPACE) {
                 if (!delete_selection()) {
                     if (m_cursor_pos > 0) {
-                        m_value_temp.erase(m_value_temp.begin() + m_cursor_pos - 1);
                         m_cursor_pos--;
+                        size_t str_pos = utf8_strpos(m_value_temp, m_cursor_pos);
+                        m_value_temp.erase(str_pos, utf8_charcount(m_value_temp[str_pos]));
                     }
                 }
             } else if (key == GLFW_KEY_DELETE) {
                 if (!delete_selection()) {
-                    if (m_cursor_pos < (int) m_value_temp.length())
-                        m_value_temp.erase(m_value_temp.begin() + m_cursor_pos);
+                    if (m_cursor_pos < (int) utf8_glyphlen(m_value_temp)) {
+                        size_t str_pos = utf8_strpos(m_value_temp, m_cursor_pos);
+                        m_value_temp.erase(str_pos, utf8_charcount(m_value_temp[str_pos]));
+                    }
                 }
             } else if (key == GLFW_KEY_ENTER) {
                 if (!m_committed)
                     focus_event(false);
             } else if (key == GLFW_KEY_A && modifiers == SYSTEM_COMMAND_MOD) {
-                m_cursor_pos = (int) m_value_temp.length();
+                m_cursor_pos = (int) utf8_glyphlen(m_value_temp);
                 m_selection_pos = 0;
             } else if (key == GLFW_KEY_X && modifiers == SYSTEM_COMMAND_MOD) {
                 copy_selection();
@@ -479,12 +497,14 @@ bool TextBox::keyboard_event(int key, int /* scancode */, int action, int modifi
 }
 
 bool TextBox::keyboard_character_event(unsigned int codepoint) {
+    std::cout << "KCE: codepoint(int)" << codepoint << std::endl;  // XXX
+    std::cout << "KCE: codepoint(utf-8)" << utf8(codepoint) << std::endl;  // XXX
     if (m_editable && focused()) {
-        std::ostringstream convert;
-        convert << (char) codepoint;
+        std::string input = utf8(codepoint);
 
         delete_selection();
-        m_value_temp.insert(m_cursor_pos, convert.str());
+        size_t str_pos = utf8_strpos(m_value_temp, m_cursor_pos);
+        m_value_temp.insert(str_pos, input);
         m_cursor_pos++;
 
         m_valid_format = (m_value_temp == "") || check_format(m_value_temp, m_format);
@@ -523,8 +543,11 @@ bool TextBox::copy_selection() {
         if (begin > end)
             std::swap(begin, end);
 
+        size_t sbegin = utf8_strpos(m_value_temp, begin);
+        size_t send = utf8_strpos(m_value_temp, end);
+
         glfwSetClipboardString(sc->glfw_window(),
-                               m_value_temp.substr(begin, end).c_str());
+                               m_value_temp.substr(sbegin, send).c_str());
         return true;
     }
 
@@ -536,8 +559,10 @@ void TextBox::paste_from_clipboard() {
     if (!sc)
         return;
     const char* cbstr = glfwGetClipboardString(sc->glfw_window());
-    if (cbstr)
-        m_value_temp.insert(m_cursor_pos, std::string(cbstr));
+    if (cbstr) {
+        size_t str_pos = utf8_strpos(m_value_temp, m_cursor_pos);
+        m_value_temp.insert(str_pos, std::string(cbstr));
+    }
 }
 
 bool TextBox::delete_selection() {
@@ -548,11 +573,14 @@ bool TextBox::delete_selection() {
         if (begin > end)
             std::swap(begin, end);
 
-        if (begin == end - 1)
-            m_value_temp.erase(m_value_temp.begin() + begin);
+        size_t sbegin = utf8_strpos(m_value_temp, begin);
+        size_t send = utf8_strpos(m_value_temp, end);
+
+        if (sbegin == send - 1)
+            m_value_temp.erase(m_value_temp.begin() + sbegin);
         else
-            m_value_temp.erase(m_value_temp.begin() + begin,
-                               m_value_temp.begin() + end);
+            m_value_temp.erase(m_value_temp.begin() + sbegin,
+                               m_value_temp.begin() + send);
 
         m_cursor_pos = begin;
         m_selection_pos = -1;

--- a/src/textbox.cpp
+++ b/src/textbox.cpp
@@ -497,8 +497,6 @@ bool TextBox::keyboard_event(int key, int /* scancode */, int action, int modifi
 }
 
 bool TextBox::keyboard_character_event(unsigned int codepoint) {
-    std::cout << "KCE: codepoint(int)" << codepoint << std::endl;  // XXX
-    std::cout << "KCE: codepoint(utf-8)" << utf8(codepoint) << std::endl;  // XXX
     if (m_editable && focused()) {
         std::string input = utf8(codepoint);
 

--- a/src/textbox.cpp
+++ b/src/textbox.cpp
@@ -367,11 +367,12 @@ bool TextBox::mouse_drag_event(const Vector2i &p, const Vector2i &/* rel */,
 
 bool TextBox::focus_event(bool focused) {
     /*
-     * Workaround to allow input from input method (when using Japanese, etc.)
-     * When using IM, an application switch between nanogui application and
-     * IM occurs. When back from IM, focus_event() is invoked without mouse
-     * being pressed on the Screen. When such event is detected, leave focuses
-     * as it was before the application switch to the IM.
+     * Workaround to allow input from an input method (when using Japanese,
+     * etc.) When using an IM, an application switch between the nanogui
+     * application and the IM occurs. When back from the IM, focus_event()
+     * is invoked without mouse being pressed on the Screen. When such
+     * event is detected, leave focus as it was before the application
+     * switch to the IM.
      */
     Widget* p = this;
     while(p->parent() != nullptr)


### PR DESCRIPTION
Enable input of non-ascii unicode characters for TextBox.
Enable input from Input Method (like mozc for Japanese) for TextBox.

I could not find a way to distinguish "Enter key solely pressed" and "Enter key when committing conversion in the Input Method". To enable input from an Input Method, I changed that text in TextBox is not committed at ENTER. Now text is committed only when mouse left button is pressed on other the the TextBox.
I hope this specification change is accepted, or someone let me know the way to distinguish the two ENTER.