### PR TITLE
Tweak CMakeLists.txt with necessary OpenGL and GLFW changes to get Linux/Wayland working

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
     url = https://github.com/wjakob/nanovg_metal
 [submodule "ext/glfw"]
     path = ext/glfw
-    url = https://github.com/wjakob/glfw
+    url = https://github.com/glfw/glfw
 [submodule "ext/nanobind"]
 	path = ext/nanobind
 	url = https://github.com/wjakob/nanobind

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,9 +220,7 @@ if (NANOGUI_BUILD_GLFW)
   set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL " " FORCE)
   set(GLFW_BUILD_TESTS OFF CACHE BOOL " " FORCE)
   set(GLFW_BUILD_DOCS OFF CACHE BOOL " " FORCE)
-  set(GLFW_BUILD_INSTALL OFF CACHE BOOL " " FORCE)
-  set(GLFW_INSTALL OFF CACHE BOOL " " FORCE)
-  set(GLFW_USE_CHDIR OFF CACHE BOOL " " FORCE)
+  set(GLFW_INSTALL NANOGUI_INSTALL CACHE BOOL " " FORCE) # install GLFW if nanogui install requested
   set(BUILD_SHARED_LIBS ${NANOGUI_BUILD_SHARED} CACHE BOOL " " FORCE)
 
   if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -231,18 +229,11 @@ if (NANOGUI_BUILD_GLFW)
   endif()
 
   add_subdirectory(ext/glfw)
-
-  # Two targets have now been defined: `glfw_objects`, which will be merged into
-  # NanoGUI at the end, and `glfw`.  The `glfw` target is the library itself
-  # (e.g., libglfw.so), but can be skipped as we do not need to link against it
-  # (because we merge `glfw_objects` into NanoGUI).  Skipping is required for
-  # XCode, but preferable for all build systems (reduces build artifacts).
-  set_target_properties(glfw PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
+  list(APPEND NANOGUI_LIBS glfw)
 
   mark_as_advanced(
-    GLFW_BUILD_DOCS GLFW_BUILD_EXAMPLES GLFW_BUILD_INSTALL GLFW_BUILD_TESTS
-    GLFW_DOCUMENT_INTERNALS GLFW_INSTALL GLFW_USE_CHDIR GLFW_USE_MENUBAR
-    GLFW_USE_OSMESA GLFW_VULKAN_STATIC GLFW_USE_RETINA GLFW_USE_MIR
+    GLFW_BUILD_DOCS GLFW_BUILD_EXAMPLES GLFW_BUILD_TESTS
+    GLFW_INSTALL GLFW_USE_OSMESA GLFW_VULKAN_STATIC
     BUILD_SHARED_LIBS USE_MSVC_RUNTIME_LIBRARY_DLL)
 endif()
 
@@ -302,9 +293,10 @@ elseif (APPLE)
   list(APPEND NANOGUI_EXTRA src/darwin.mm src/autorelease.mm)
   set_property(SOURCE src/autorelease.mm PROPERTY COMPILE_FLAGS -fno-objc-arc)
 elseif (CMAKE_SYSTEM MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "BSD")
-  list(APPEND NANOGUI_LIBS X11 pthread)
+  list(APPEND NANOGUI_LIBS pthread)
   if (NANOGUI_BACKEND STREQUAL "OpenGL")
-    list(APPEND NANOGUI_LIBS GL)
+    find_package(OpenGL REQUIRED COMPONENTS OpenGL)
+    list(APPEND NANOGUI_LIBS OpenGL::OpenGL)
   elseif (NANOGUI_BACKEND STREQUAL "GLES 2")
     list(APPEND NANOGUI_LIBS GLESv2)
   elseif (NANOGUI_BACKEND STREQUAL "GLES 3")
@@ -377,10 +369,6 @@ endif()
 if (APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # Use automatic reference counting for Objective-C portions
   add_compile_options(-fobjc-arc)
-endif()
-
-if (NANOGUI_BUILD_GLFW)
-  list(APPEND NANOGUI_EXTRA $<TARGET_OBJECTS:glfw_objects>)
 endif()
 
 # Compile main NanoGUI library
@@ -515,11 +503,6 @@ if (NANOGUI_INSTALL)
   install(DIRECTORY ext/nanovg/src/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nanovg
           FILES_MATCHING PATTERN "*.h")
 
-  if (NANOGUI_BUILD_GLFW)
-    install(DIRECTORY ext/glfw/include/GLFW DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-            FILES_MATCHING PATTERN "*.h")
-  endif()
-
   if (NANOGUI_BUILD_GLAD)
     install(DIRECTORY ext/glad/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/glad
             FILES_MATCHING PATTERN "*.h")
@@ -564,10 +547,10 @@ if (NANOGUI_BUILD_EXAMPLES)
   add_executable(example4      src/example4.cpp)
   add_executable(example_icons src/example_icons.cpp)
 
-  target_link_libraries(example1      nanogui)
+  target_link_libraries(example1      nanogui glfw)
   target_link_libraries(example2      nanogui)
   target_link_libraries(example3      nanogui ${NANOGUI_LIBS}) # For OpenGL
-  target_link_libraries(example4      nanogui)
+  target_link_libraries(example4      nanogui glfw)
   target_link_libraries(example_icons nanogui)
 
   # Copy icons for example application

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -77,7 +77,7 @@ file as follows (this assumes that ``nanogui`` lives in the directory
     add_subdirectory(ext/nanogui)
 
     # For reliability of parallel build, make the NanoGUI targets dependencies
-    set_property(TARGET glfw glfw_objects nanogui PROPERTY FOLDER "dependencies")
+    set_property(TARGET glfw nanogui PROPERTY FOLDER "dependencies")
 
 Required Variables Exposed
 ----------------------------------------------------------------------------------------

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -3,7 +3,7 @@ if (NOT NANOGUI_BUILD_SHARED)
   set_target_properties(nanogui PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
   if (NANOGUI_BUILD_GLFW)
-    set_target_properties(glfw_objects PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    set_target_properties(glfw PROPERTIES POSITION_INDEPENDENT_CODE ON)
   endif()
 endif()
 


### PR DESCRIPTION
On my Wayland machine, if I supply the `GLFW_USE_WAYLAND=ON` option to cmake via the command line, this allows me to compile the code and run the resultant binary successfully. 

I'm no cmake wizard, so I had some trouble getting this to work with the prior `glfw_objects` workflow -- instead, I switched nanogui to just use GLFW [the way it recommends](https://www.glfw.org/docs/3.3/build_guide.html#build_link_cmake_source). As part of this, I switched the submodule to the main GLFW repository, as as far as I could tell, the custom features provided by the fork were no longer used. This means GLFW will be easier to update in the future. 

I've tested this on Linux/X11 and Linux/Wayland, and I can confirm this works on both, but I don't have a Windows or Mac machine to test whether I broke something there. 

I expect this to fix #103.