### PR TITLE
Fix resource path in example1.py

### DIFF
--- a/src/python/example1.py
+++ b/src/python/example1.py
@@ -137,7 +137,7 @@ class TestApp(Screen):
             try:
                 icons_data = nanogui.load_image_directory(self.nvg_context(), "../icons")
             except:
-                icons_data = nanogui.load_image_directory(self.nvg_context(), "../resources/icons")
+                icons_data = nanogui.load_image_directory(self.nvg_context(), "../../resources/icons")
 
 
         Label(window, "Image panel & scroll panel", "sans-bold")


### PR DESCRIPTION
Adjust resource path, so example1.py works when running from it's own directory.