### PR TITLE
Make Widget::set_size() virtual

### DIFF
--- a/include/nanogui/widget.h
+++ b/include/nanogui/widget.h
@@ -73,7 +73,7 @@ public:
     /// Return the size of the widget
     const Vector2i &size() const { return m_size; }
     /// set the size of the widget
-    void set_size(const Vector2i &size) { m_size = size; }
+    virtual void set_size(const Vector2i &size) { m_size = size; }
 
     /// Return the width of the widget
     int width() const { return m_size.x(); }


### PR DESCRIPTION
Disclaimer: I know very little about C++. That said: set_size() is overridden in Screen but set_size() was not marked as virtual leading to the overridden method not being called correctly. Adding the virtual keyword fixes the issue for me.