### PR TITLE
Multiple small improvements

### DIFF
--- a/include/nanogui/textarea.h
+++ b/include/nanogui/textarea.h
@@ -74,10 +74,10 @@ public:
     int padding() const { return m_padding; }
 
     /// Set whether the text can be selected using the mouse
-    void set_selectable(int selectable) { m_selectable = selectable; }
+    void set_selectable(bool selectable) { m_selectable = selectable; }
 
     /// Return whether the text can be selected using the mouse
-    int is_selectable() const { return m_selectable; }
+    bool is_selectable() const { return m_selectable; }
 
     /// Append text at the end of the widget
     void append(const std::string &text);

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -77,7 +77,6 @@ void TabWidgetBase::perform_layout(NVGcontext* ctx) {
     nvgFontSize(ctx, font_size());
     nvgTextAlign(ctx, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
 
-    m_tab_offsets.clear();
     int width = 0;
     float unused[4];
     for (const std::string &label : m_tab_captions) {

--- a/src/textarea.cpp
+++ b/src/textarea.cpp
@@ -156,7 +156,7 @@ void TextArea::draw(NVGcontext *ctx) {
         std::swap(selection_start, selection_end);
         flip = true;
     }
-    if (m_selection_end != Vector2i(-1) && m_selection_end != Vector2i(-1)) {
+    if (m_selection_start != Vector2i(-1) && m_selection_end != Vector2i(-1)) {
         nvgBeginPath(ctx);
         nvgFillColor(ctx, m_selection_color);
         if (selection_end.y() == selection_start.y()) {
@@ -186,7 +186,7 @@ void TextArea::draw(NVGcontext *ctx) {
 
         Vector2i offset = block.offset + m_pos + m_padding;
 
-        if (m_selection_end != Vector2i(-1) && m_selection_end != Vector2i(-1) &&
+        if (m_selection_start != Vector2i(-1) && m_selection_end != Vector2i(-1) &&
             offset.y() > selection_start.y() && offset.y() < selection_end.y()) {
             nvgFillColor(ctx, m_selection_color);
             nvgBeginPath(ctx);


### PR DESCRIPTION
TextArea::draw() checks there's a selected area before drawing highlighted background. However, there's a duplicate condition `m_selection_end != Vector2i(-1)` in this check, presumably due to a typo. Let's do this check properly, using the same rules as in TextArea::keyboard_event().

As TextArea::m_selectable field is a bool, it makes sense for TextArea::is_selectable() and TextArea::set_selectable() methods to return and accept bool.

Also it's enough to clear m_tab_offsets once in TabWidgetBase::perform_layout().