### PR TITLE
Added library refence to allow python binding to cast to std::pair

### DIFF
--- a/src/python/python.h
+++ b/src/python/python.h
@@ -10,6 +10,9 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 #include <nanobind/stl/function.h>
+#include <nanobind/stl/pair.h>
+
+
 #include <nanogui/python.h>
 #include "py_doc.h"
 


### PR DESCRIPTION
Solves issue #164 where setting the range of sliders in python results in a casting error. The issue is that the python binding code was missing the reference to:
```
#include <nanobind/stl/pair.h>
```

Adding this resolves the issue.