### PR TITLE
Update to latest nanobind and python 3.12 support

### DIFF
--- a/include/nanogui/button.h
+++ b/include/nanogui/button.h
@@ -25,7 +25,7 @@ NAMESPACE_BEGIN(nanogui)
 class NANOGUI_EXPORT Button : public Widget {
 public:
     /// Flags to specify the button behavior (can be combined with binary OR)
-    enum Flags {
+    enum Flags : int32_t{
         NormalButton = (1 << 0), ///< A normal button.
         RadioButton  = (1 << 1), ///< A radio button.
         ToggleButton = (1 << 2), ///< A toggle button.
@@ -79,7 +79,7 @@ public:
     /// The current flags of this Button (see \ref nanogui::Button::Flags for options).
     int flags() const { return m_flags; }
     /// Sets the flags of this Button (see \ref nanogui::Button::Flags for options).
-    void set_flags(int button_flags) { m_flags = button_flags; }
+    void set_flags(Flags button_flags) { m_flags = button_flags; }
 
     /// The position of the icon for this Button.
     IconPosition icon_position() const { return m_icon_position; }
@@ -137,7 +137,7 @@ protected:
     bool m_pushed;
 
     /// The current flags of this button (see \ref nanogui::Button::Flags for options).
-    int m_flags;
+    Flags m_flags;
 
     /// The background color of this Button.
     Color m_background_color;

--- a/include/nanogui/button.h
+++ b/include/nanogui/button.h
@@ -79,7 +79,7 @@ public:
     /// The current flags of this Button (see \ref nanogui::Button::Flags for options).
     int flags() const { return m_flags; }
     /// Sets the flags of this Button (see \ref nanogui::Button::Flags for options).
-    void set_flags(Flags button_flags) { m_flags = button_flags; }
+    void set_flags(const Flags button_flags) { m_flags = button_flags; }
 
     /// The position of the icon for this Button.
     IconPosition icon_position() const { return m_icon_position; }

--- a/include/nanogui/toolbutton.h
+++ b/include/nanogui/toolbutton.h
@@ -26,7 +26,7 @@ public:
     ToolButton(Widget *parent, int icon,
            const std::string &caption = "")
         : Button(parent, caption, icon) {
-        set_flags(Flags::RadioButton | Flags::ToggleButton);
+        set_flags(static_cast<Flags>(Flags::RadioButton | Flags::ToggleButton));
         set_fixed_size(Vector2i(25, 25));
     }
 };

--- a/src/popupbutton.cpp
+++ b/src/popupbutton.cpp
@@ -21,7 +21,7 @@ PopupButton::PopupButton(Widget *parent, const std::string &caption, int button_
 
     m_chevron_icon = m_theme->m_popup_chevron_right_icon;
 
-    set_flags(Flags::ToggleButton | Flags::PopupButton);
+    set_flags(static_cast<Flags>(Flags::ToggleButton | Flags::PopupButton));
 
     m_popup = new Popup(screen(), window());
     m_popup->set_size(Vector2i(320, 250));


### PR DESCRIPTION
This is a very small change that updates the nanobind submodule to the current master (probably a bad idea, maybe a fixed version would be preferred?) and then changes some code around the Flags enum for buttons to get it working.

Why were these changes needed? The Flags enum was treated as an integer by some functions. It seems with the latests nanobind there has been some changes to the handling of enums, which meant the casting of a enum in python to an int for the bound function does not work. This is possible related to [this](https://github.com/wjakob/nanobind/pull/533).

The solution I found was to change the functions to accept enums and perform static_casts when int->enum is needed.
