### PR TITLE
Bugfix in colorwheel.cpp

### DIFF
--- a/src/colorwheel.cpp
+++ b/src/colorwheel.cpp
@@ -270,7 +270,7 @@ void ColorWheel::set_color(const Color &rgb) {
             h = (r - g) / d + 4;
         h /= 6;
 
-        Color ch = hue2rgb(m_hue);
+        Color ch = hue2rgb(h);
         float M2 = std::max({ ch[0], ch[1], ch[2] });
         float m2 = std::min({ ch[0], ch[1], ch[2] });
 


### PR DESCRIPTION
bugfix: using uninitialized m_hue for first calculation of m_white and m_black.