### PR TITLE
Feature/render widgests on top of opengl content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ resources/nanogui-entypo
 
 compile_commands.json
 .clangd
+.cache

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -133,8 +133,6 @@ void Canvas::draw(NVGcontext *ctx) {
 
     float pixel_ratio = scr->pixel_ratio();
 
-    Widget::draw(ctx);
-
     scr->nvg_flush();
 
     Vector2i fbsize = m_size;
@@ -186,6 +184,8 @@ void Canvas::draw(NVGcontext *ctx) {
 #endif
         rp->blit_to(Vector2i(0, 0), fbsize, scr, offset);
     }
+
+    Widget::draw(ctx);
 }
 
 NAMESPACE_END(nanogui)

--- a/src/example1.cpp
+++ b/src/example1.cpp
@@ -209,6 +209,9 @@ public:
             }
         );
 
+        // Create an overlay label for the image view
+        new Label(image_view, "This is an overlay");
+
         new Label(window, "File dialog", "sans-bold");
         tools = new Widget(window);
         tools->set_layout(new BoxLayout(Orientation::Horizontal,


### PR DESCRIPTION
The Canvas class is very handy to render custom OpenGL content in the application. Since it's a widget, it can have children as well. However the content is rendered on top of the children, which makes the usage of the child widgets less idea.

With this patch the rendering order is changed, so the children will be rendered on top of the custom content. This allows e.g. adding a toolbar (e.g. tool selection) on top of a 3D view in an application.

Added a sample to example1 as well (though just a simple label)

<img width="284" alt="SCR-20250612-iqui" src="https://github.com/user-attachments/assets/050f0d42-0258-4875-8d0b-bd833e852e86" />

Also added a minor change to .gitignore to ignore the .cache folder (which seems to be created by Visual Studio Code)