### PR TITLE
fix: compilation due to missing algorithm include

### DIFF
--- a/src/colorwheel.cpp
+++ b/src/colorwheel.cpp
@@ -15,6 +15,8 @@
 #include <nanogui/theme.h>
 #include <nanogui/opengl.h>
 
+#include <algorithm>
+
 NAMESPACE_BEGIN(nanogui)
 
 ColorWheel::ColorWheel(Widget *parent, const Color& rgb)

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -21,8 +21,8 @@
 #include <nanogui/renderpass.h>
 #include <nanogui/shader.h>
 
+#include <algorithm>
 #include <cstdlib>
-#include <map>
 #include <iostream>
 
 #if defined(EMSCRIPTEN)

--- a/src/textarea.cpp
+++ b/src/textarea.cpp
@@ -15,6 +15,8 @@
 #include <nanogui/screen.h>
 #include <nanogui/vscrollpanel.h>
 
+#include <algorithm>
+
 NAMESPACE_BEGIN(nanogui)
 
 TextArea::TextArea(Widget *parent) : Widget(parent),

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -16,6 +16,8 @@
 #include <nanogui/opengl.h>
 #include <nanogui/screen.h>
 
+#include <algorithm>
+
 /* Uncomment the following definition to draw red bounding
    boxes around widgets (useful for debugging drawing code) */
 


### PR DESCRIPTION
Specifically required for nanogui's usages of `std::lower_bound`, `std::find` and `std::max(<initializer list>)`.