### PR TITLE
Fix two issues related to macOS main loop

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -863,7 +863,6 @@ bool Screen::resize_event(const Vector2i& size) {
     if (m_resize_callback)
         m_resize_callback(size);
     m_redraw = true;
-    draw_all();
     return true;
 }
 


### PR DESCRIPTION
- Removes a nested `draw_all()` call from `Screen::resize_event` that caused the application to enter a bad state (e.g. nil drawables, low framerate)
- Updates GLFW's Cocoa event loop logic to process input events in per-frame batches rather than allowing draw calls to be stalled indefinitely.