### PR TITLE
fix(widget): `preferred_size_changed()` not called on size change

### DIFF
--- a/include/nanogui/widget.h
+++ b/include/nanogui/widget.h
@@ -72,18 +72,31 @@ public:
     const Vector2i &size() const { return m_size; }
     /// set the size of the widget
     void set_size(const Vector2i &size) {
-        m_size = size;
+        if (m_size != size) {
+            m_size = size;
+            preferred_size_changed();
+        }
     }
 
     /// Return the width of the widget
     int width() const { return m_size.x(); }
     /// Set the width of the widget
-    void set_width(int width) { m_size.x() = width; }
+    void set_width(int width) {
+        if (m_size.x() != width) {
+            m_size.x() = width;
+            preferred_size_changed();
+        }
+    }
 
     /// Return the height of the widget
     int height() const { return m_size.y(); }
     /// Set the height of the widget
-    void set_height(int height) { m_size.y() = height; }
+    void set_height(int height) {
+        if (m_size.y() != height) {
+            m_size.y() = height;
+            preferred_size_changed();
+        }
+    }
 
     /**
      * \brief Set the fixed size of this widget


### PR DESCRIPTION
`set_size`, `set_width`, and `set_height` affect `preferred_size_impl` but previously did not call `preferred_size_changed`.

FWIW, this did not lead to noticeable breakage other than warnings of the form
```
NanoGUI: widget 0x6000029f0cf0 of type N7nanogui6WidgetE returned an unexpected preferred size. It appears that something updated its state but did not call preferred_size_changed() (size=[0, 10], ref=[207, 10
])! 
```
in debug mode.