### PR TITLE
fix(texture_gl): don't require GL 4.2 in mip level allocation

### DIFF
--- a/src/texture_gl.cpp
+++ b/src/texture_gl.cpp
@@ -162,6 +162,26 @@ void Texture::upload(const uint8_t *data) {
         if (data)
             CHK(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
 
+        const auto preallocate_mip_levels = [&]() {
+            GLint prev_pbo = 0;
+            CHK(glGetIntegerv(GL_PIXEL_UNPACK_BUFFER_BINDING, &prev_pbo));
+            if (prev_pbo != 0)
+                CHK(glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0));
+
+            int mip_levels = 1 + (int) floor(log2((double) std::max(m_size.x(), m_size.y())));
+            CHK(glTexParameteri(tex_mode, GL_TEXTURE_MAX_LEVEL, mip_levels - 1));
+
+            for (int level = 0; level < mip_levels; ++level) {
+                GLsizei w = std::max(1, (GLsizei) m_size.x() >> level);
+                GLsizei h = std::max(1, (GLsizei) m_size.y() >> level);
+                CHK(glTexImage2D(tex_mode, level, internal_format_gl, w, h, 0,
+                                 pixel_format_gl, component_format_gl, nullptr));
+            }
+
+            if (prev_pbo != 0)
+                CHK(glBindBuffer(GL_PIXEL_UNPACK_BUFFER, prev_pbo));
+        };
+
 #if defined(NANOGUI_USE_OPENGL)
         if (data) {
             CHK(glPixelStorei(GL_UNPACK_ROW_LENGTH, 0));
@@ -170,10 +190,10 @@ void Texture::upload(const uint8_t *data) {
         }
 
         if (m_samples == 1) {
+            // Pre-allocate mip levels to prevent a pipeline stall upon future glGenerateMipmap() calls
             if (m_min_interpolation_mode == InterpolationMode::Trilinear ||
                 m_mag_interpolation_mode == InterpolationMode::Trilinear) {
-                int mip_levels = 1 + (int) floor(log2((double) std::max(m_size.x(), m_size.y())));
-                CHK(glTexStorage2D(tex_mode, mip_levels, internal_format_gl, m_size.x(), m_size.y()));
+                preallocate_mip_levels();
                 CHK(glTexSubImage2D(tex_mode, 0, 0, 0, (GLsizei) m_size.x(), (GLsizei) m_size.y(),
                                     pixel_format_gl, component_format_gl, data));
             } else
@@ -184,15 +204,13 @@ void Texture::upload(const uint8_t *data) {
             CHK(glTexImage2DMultisample(tex_mode, m_samples, internal_format_gl,
                                         (GLsizei) m_size.x(), (GLsizei) m_size.y(), false));
 #else
-#if defined(NANOGUI_USE_GLES) && NANOGUI_GLES_VERSION >= 3
+        // Pre-allocate mip levels to prevent a pipeline stall upon future glGenerateMipmap() calls
         if (m_min_interpolation_mode == InterpolationMode::Trilinear ||
             m_mag_interpolation_mode == InterpolationMode::Trilinear) {
-            int mip_levels = 1 + (int) floor(log2((double) std::max(m_size.x(), m_size.y())));
-            CHK(glTexStorage2D(tex_mode, mip_levels, internal_format_gl, m_size.x(), m_size.y()));
+            preallocate_mip_levels();
             CHK(glTexSubImage2D(tex_mode, 0, 0, 0, (GLsizei) m_size.x(), (GLsizei) m_size.y(),
                                 pixel_format_gl, component_format_gl, data));
         } else
-#endif
             CHK(glTexImage2D(tex_mode, 0, internal_format_gl, (GLsizei) m_size.x(),
                              (GLsizei) m_size.y(), 0, pixel_format_gl, component_format_gl, data));
 #endif

--- a/src/texture_gl.cpp
+++ b/src/texture_gl.cpp
@@ -249,6 +249,16 @@ void Texture::upload_async(const uint8_t *data, void (*callback)(void*), void *p
 
     void *ptr = glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, dataSize,
       GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT);
+
+    if (!ptr) {
+        CHK(glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0));
+        CHK(glDeleteBuffers(1, &pbo));
+
+        callback(payload);
+
+        throw std::runtime_error("Texture::upload_async(): failed to map PBO; likely OOM!");
+    }
+
     memcpy(ptr, data, dataSize);
     CHK(glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER));
 


### PR DESCRIPTION
Sorry, my previous PR introduced the usage of `glTexStorage2D` for mip level pre-allocation which isn't available below OpenGL 4.2. This PR uses `glTexImage2D` instead -- verified bringing the same performance benefit. And as a by-product also supports GLES 2.