### PR TITLE
Use perfect forwarding in Widget::add

### DIFF
--- a/include/nanogui/widget.h
+++ b/include/nanogui/widget.h
@@ -15,6 +15,8 @@
 #include <nanogui/object.h>
 #include <nanogui/theme.h>
 
+#include <utility>
+
 NAMESPACE_BEGIN(nanogui)
 
 enum class Cursor; // do not put a docstring, this is already documented
@@ -188,8 +190,8 @@ public:
 
     /// Variadic shorthand notation to construct and add a child widget
     template<typename WidgetClass, typename... Args>
-    WidgetClass* add(const Args&... args) {
-        return new WidgetClass(this, args...);
+    WidgetClass* add(Args&&... args) {
+        return new WidgetClass(this, std::forward<Args>(args)...);
     }
 
     /// Walk up the hierarchy and return the parent window


### PR DESCRIPTION
Before this change, Widget::add took the constructor arguments for WidgetClass as `const Args&...`. Converting the arguments to const reference made creating a widget by calling add on the parent behave differently from creating a widget by passing the parent to its constructor. Specifically

* It was not possible to use add<WidgetClass> if the constructor of WidgetClass took some of its arguments by non-const reference,
* If WidgetClass took some of its arguments by value and moved them into data members, add<WidgetClass> would make an unnecessary copy.

After the change, the following works.

```
class MyWidget : public nanogui::Widget {
public:
    MyWidget(
        nanogui::Widget *parent,
        bool &external_flag,
        std::vector<int> heavy_vector)
        : nanogui::Widget{parent}
        , m_external_flag{external_flag}
        , m_heavy_vector{std::move(heavy_vector)}
    {}
private:
    bool& m_external_flag;
    std::vector<int> m_heavy_vector;
};

bool flag = false;

void add_my_widget(nanogui::Widget* parent) {
    parent->add<MyWidget>(
        flag,                        // Compiles.
        std::vector<int>(10000));    // Moved, not copied.
}
```

Note that existing call sites don't break, since the forwarding reference `Args&&...` accepts everything that `const Args&&...` did.